### PR TITLE
profiles: add 0.8.1 profile schema

### DIFF
--- a/vulkan/profiles-0.8-latest.json
+++ b/vulkan/profiles-0.8-latest.json
@@ -7823,7 +7823,7 @@
                             }
                         },
                         "optionals": {
-                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "description": "The list of optional capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.0-118.json
+++ b/vulkan/profiles-0.8.0-118.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-117.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.117",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-118.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.118",
     "additionalProperties": true,
     "required": [
         "capabilities",

--- a/vulkan/profiles-0.8.0-207.json
+++ b/vulkan/profiles-0.8.0-207.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-207.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.207",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-208.json
+++ b/vulkan/profiles-0.8.0-208.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-208.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.208",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-209.json
+++ b/vulkan/profiles-0.8.0-209.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-209.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-210.json
+++ b/vulkan/profiles-0.8.0-210.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-210.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.210",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-211.json
+++ b/vulkan/profiles-0.8.0-211.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-211.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.211",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-212.json
+++ b/vulkan/profiles-0.8.0-212.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-212.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.212",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-213.json
+++ b/vulkan/profiles-0.8.0-213.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-213.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.213",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-214.json
+++ b/vulkan/profiles-0.8.0-214.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-214.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.214",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-215.json
+++ b/vulkan/profiles-0.8.0-215.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-215.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.215",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-216.json
+++ b/vulkan/profiles-0.8.0-216.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-216.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.216",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-217.json
+++ b/vulkan/profiles-0.8.0-217.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-217.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.217",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-218.json
+++ b/vulkan/profiles-0.8.0-218.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-218.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.218",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-219.json
+++ b/vulkan/profiles-0.8.0-219.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-219.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.219",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-220.json
+++ b/vulkan/profiles-0.8.0-220.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-220.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.219",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-221.json
+++ b/vulkan/profiles-0.8.0-221.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-221.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.221",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-222.json
+++ b/vulkan/profiles-0.8.0-222.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-222.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.222",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-223.json
+++ b/vulkan/profiles-0.8.0-223.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-223.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.223",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-224.json
+++ b/vulkan/profiles-0.8.0-224.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-224.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.224",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-225.json
+++ b/vulkan/profiles-0.8.0-225.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-225.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.225",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-226.json
+++ b/vulkan/profiles-0.8.0-226.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-226.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.226",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-227.json
+++ b/vulkan/profiles-0.8.0-227.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-227.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.227",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-228.json
+++ b/vulkan/profiles-0.8.0-228.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-228.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.228",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-229.json
+++ b/vulkan/profiles-0.8.0-229.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-229.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.229",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.0-230.json
+++ b/vulkan/profiles-0.8.0-230.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.0-230.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
     "additionalProperties": true,
     "required": [

--- a/vulkan/profiles-0.8.1-100.json
+++ b/vulkan/profiles-0.8.1-100.json
@@ -1,0 +1,3694 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-100.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.100",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-100.json
+++ b/vulkan/profiles-0.8.1-100.json
@@ -3659,7 +3659,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-101.json
+++ b/vulkan/profiles-0.8.1-101.json
@@ -1,0 +1,3739 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-101.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.101",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-101.json
+++ b/vulkan/profiles-0.8.1-101.json
@@ -3704,7 +3704,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-102.json
+++ b/vulkan/profiles-0.8.1-102.json
@@ -1,0 +1,3760 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-103.json
+++ b/vulkan/profiles-0.8.1-103.json
@@ -3725,7 +3725,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-103.json
+++ b/vulkan/profiles-0.8.1-103.json
@@ -1,0 +1,3760 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-103.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.103",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-104.json
+++ b/vulkan/profiles-0.8.1-104.json
@@ -3725,7 +3725,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-104.json
+++ b/vulkan/profiles-0.8.1-104.json
@@ -1,0 +1,3760 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-104.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.104",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-105.json
+++ b/vulkan/profiles-0.8.1-105.json
@@ -3759,7 +3759,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-105.json
+++ b/vulkan/profiles-0.8.1-105.json
@@ -1,0 +1,3794 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-105.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.105",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-106.json
+++ b/vulkan/profiles-0.8.1-106.json
@@ -3771,7 +3771,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-106.json
+++ b/vulkan/profiles-0.8.1-106.json
@@ -1,0 +1,3806 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-106.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.106",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-107.json
+++ b/vulkan/profiles-0.8.1-107.json
@@ -3774,7 +3774,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-107.json
+++ b/vulkan/profiles-0.8.1-107.json
@@ -1,0 +1,3809 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-107.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.107",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-108.json
+++ b/vulkan/profiles-0.8.1-108.json
@@ -3804,7 +3804,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-108.json
+++ b/vulkan/profiles-0.8.1-108.json
@@ -1,0 +1,3839 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-108.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.108",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-109.json
+++ b/vulkan/profiles-0.8.1-109.json
@@ -3804,7 +3804,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-109.json
+++ b/vulkan/profiles-0.8.1-109.json
@@ -1,0 +1,3839 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-109.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.109",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-110.json
+++ b/vulkan/profiles-0.8.1-110.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-110.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.110",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -508,6 +517,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -604,7 +622,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -646,7 +664,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,6 +1405,7 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
@@ -2118,6 +2146,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2263,19 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2254,6 +2294,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2308,6 +2351,12 @@
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_decorate_string": {
@@ -2466,10 +2515,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2576,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2623,8 +2681,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2637,6 +2698,9 @@
                             },
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
@@ -2658,6 +2722,9 @@
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,8 +2759,11 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
@@ -2704,11 +2774,20 @@
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"

--- a/vulkan/profiles-0.8.1-111.json
+++ b/vulkan/profiles-0.8.1-111.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-111.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.111",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -508,6 +517,30 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -604,7 +637,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -618,6 +651,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -646,7 +697,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1438,8 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1875,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2118,6 +2191,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2308,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2254,6 +2342,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2310,6 +2401,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2420,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2466,10 +2569,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2630,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2689,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2738,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2637,6 +2755,9 @@
                             },
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
@@ -2658,6 +2779,12 @@
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,11 +2819,20 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2INTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
@@ -2704,11 +2840,20 @@
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2818,6 +2963,9 @@
                             },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"

--- a/vulkan/profiles-0.8.1-112.json
+++ b/vulkan/profiles-0.8.1-112.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-112.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.112",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -508,6 +517,30 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -604,7 +637,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -618,6 +651,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -646,7 +697,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1438,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1876,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2118,6 +2192,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2309,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2254,6 +2343,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2310,6 +2402,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2421,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2466,10 +2570,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2631,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2690,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2739,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2637,6 +2756,9 @@
                             },
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
@@ -2658,6 +2780,12 @@
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,11 +2820,20 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2INTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
@@ -2704,11 +2841,20 @@
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2818,6 +2964,9 @@
                             },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"

--- a/vulkan/profiles-0.8.1-113.json
+++ b/vulkan/profiles-0.8.1-113.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-113.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.113",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -508,6 +517,30 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -604,7 +637,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -622,6 +664,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -630,6 +690,15 @@
                     "type": "boolean"
                 },
                 "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
                     "type": "boolean"
                 }
             }
@@ -646,7 +715,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1456,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1894,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2118,6 +2210,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2327,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2256,6 +2363,9 @@
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
@@ -2274,6 +2384,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2287,6 +2400,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2426,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2445,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2466,10 +2594,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2655,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2714,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2763,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2637,6 +2780,9 @@
                             },
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
@@ -2658,6 +2804,12 @@
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,23 +2844,47 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2INTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2818,6 +2994,9 @@
                             },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"

--- a/vulkan/profiles-0.8.1-114.json
+++ b/vulkan/profiles-0.8.1-114.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-114.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.114",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -508,6 +517,39 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -604,7 +646,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -622,6 +673,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -630,6 +699,15 @@
                     "type": "boolean"
                 },
                 "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
                     "type": "boolean"
                 }
             }
@@ -646,7 +724,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1465,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1903,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2118,6 +2219,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2336,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2256,6 +2372,9 @@
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
@@ -2274,6 +2393,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2287,6 +2409,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2435,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2454,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2555,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2466,10 +2606,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2667,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2726,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2775,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2637,6 +2792,9 @@
                             },
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
@@ -2658,6 +2816,15 @@
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,23 +2859,47 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2INTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2INTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2818,6 +3009,9 @@
                             },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"

--- a/vulkan/profiles-0.8.1-115.json
+++ b/vulkan/profiles-0.8.1-115.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-115.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.115",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -504,6 +501,39 @@
             "additionalProperties": false,
             "properties": {
                 "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +634,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +669,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +703,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +724,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1465,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1903,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1864,6 +1965,24 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2237,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2354,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2256,6 +2390,9 @@
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
@@ -2274,6 +2411,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2287,6 +2427,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2453,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2472,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2573,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2466,10 +2624,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2685,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2744,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2793,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2811,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,14 +2826,20 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,23 +2874,53 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2819,11 +3031,17 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"

--- a/vulkan/profiles-0.8.1-116.json
+++ b/vulkan/profiles-0.8.1-116.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-116.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.116",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -504,6 +501,39 @@
             "additionalProperties": false,
             "properties": {
                 "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +634,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +669,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +703,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +724,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1465,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1814,6 +1903,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1864,6 +1965,24 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2237,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,10 +2354,22 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -2256,6 +2390,9 @@
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
@@ -2274,6 +2411,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2287,6 +2427,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2453,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2472,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2573,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2466,10 +2624,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2685,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2744,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2793,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2811,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,14 +2826,20 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
                             },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
@@ -2692,23 +2874,53 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2819,11 +3031,17 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"

--- a/vulkan/profiles-0.8.1-117.json
+++ b/vulkan/profiles-0.8.1-117.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-117.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.117",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +505,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +555,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +667,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +702,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +736,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +766,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1507,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1547,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1691,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1814,6 +1961,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1864,6 +2023,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2313,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,16 +2430,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2470,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2493,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2508,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2541,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2560,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2661,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2466,10 +2712,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2773,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2832,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2881,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2899,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2914,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2692,23 +2968,56 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3083,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2819,11 +3131,20 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3219,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3237,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3255,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3273,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3291,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3309,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3327,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-118.json
+++ b/vulkan/profiles-0.8.1-118.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-118.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.118",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +505,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +555,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +667,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +702,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +736,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +766,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1507,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1547,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1691,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1814,6 +1961,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceShadingRateImagePropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1864,6 +2023,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2313,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2232,16 +2430,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2470,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2493,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2508,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2541,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2560,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2661,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2466,10 +2712,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2773,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2832,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2881,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2899,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2914,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2692,23 +2968,56 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3083,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2819,11 +3131,20 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3219,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3237,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3255,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3273,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3291,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3309,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3327,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-119.json
+++ b/vulkan/profiles-0.8.1-119.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-119.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.119",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +505,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +555,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +667,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +702,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +736,36 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +778,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1519,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1559,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1703,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1925,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +1993,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2059,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2349,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2373,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2383,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2472,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2512,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2535,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2550,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2583,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2602,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2703,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2719,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2466,10 +2757,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2818,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2877,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2926,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2944,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2959,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2692,23 +3013,59 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3131,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3176,26 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3270,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3288,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3306,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3324,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3342,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3360,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3378,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-120.json
+++ b/vulkan/profiles-0.8.1-120.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-120.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.120",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -375,6 +375,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +481,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +505,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +555,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +667,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +702,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +736,36 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +778,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1519,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1559,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1703,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1925,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +1993,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2059,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2349,9 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2373,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2383,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2472,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2512,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2535,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2550,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2583,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2602,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2703,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2719,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2466,10 +2757,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2818,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2877,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2926,11 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2944,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2959,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2692,23 +3013,59 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3131,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3176,26 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3270,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3288,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3306,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3324,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3342,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3360,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3378,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-121.json
+++ b/vulkan/profiles-0.8.1-121.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-121.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.121",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +720,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +754,36 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +796,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1537,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1577,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1721,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1943,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2011,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2077,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2367,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2394,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2404,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2493,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2533,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2556,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2571,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2604,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2623,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2724,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2740,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2466,10 +2778,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2839,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2898,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2947,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2968,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2983,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3018,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3040,59 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3158,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3203,26 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3297,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3315,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3333,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3351,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3369,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3387,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3405,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-122.json
+++ b/vulkan/profiles-0.8.1-122.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-122.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.122",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +720,24 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +754,36 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +796,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1537,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1577,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1721,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1943,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2011,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2077,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2367,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2394,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2404,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2493,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2533,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2556,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2571,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2604,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2323,6 +2623,12 @@
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2724,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2740,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2466,10 +2778,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2839,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2898,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2947,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2968,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2983,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3018,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3040,59 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3158,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3203,26 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3297,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3315,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3333,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3351,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3369,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3387,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3405,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-123.json
+++ b/vulkan/profiles-0.8.1-123.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-123.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.123",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,32 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +720,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +763,36 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +805,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1546,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1586,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1730,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1952,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2020,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2086,42 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2118,6 +2376,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2403,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2413,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2502,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2542,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2565,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2580,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2613,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2628,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2736,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2752,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2457,6 +2781,9 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
                                 "type": "integer"
                             },
@@ -2466,10 +2793,16 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2854,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2913,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2962,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +2983,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +2998,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3033,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3055,62 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3176,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3221,26 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3315,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3333,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3351,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3369,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3387,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3405,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3423,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-124.json
+++ b/vulkan/profiles-0.8.1-124.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-124.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.124",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +732,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +775,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +826,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1567,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1607,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1751,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1973,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2041,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2107,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2406,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2433,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2443,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2532,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2572,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2595,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2610,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2643,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2658,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2766,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2782,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2448,6 +2802,9 @@
                             "VK_KHR_shader_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_draw_parameters": {
                                 "type": "integer"
                             },
@@ -2455,6 +2812,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -2466,10 +2826,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2890,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2949,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +2998,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3019,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3034,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3069,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3091,68 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3218,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3263,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3360,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3378,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3396,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3414,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3432,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3450,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3468,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-125.json
+++ b/vulkan/profiles-0.8.1-125.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-125.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.125",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +732,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +775,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +826,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1567,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1607,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1751,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1973,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2041,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2107,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2406,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2433,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2443,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2532,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2572,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2595,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2610,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2643,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2658,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2766,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2782,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2448,6 +2802,9 @@
                             "VK_KHR_shader_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_draw_parameters": {
                                 "type": "integer"
                             },
@@ -2457,7 +2814,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2829,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2893,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2952,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3001,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3022,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3037,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3072,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3094,68 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3221,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3266,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3363,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3381,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3399,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3417,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3435,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3453,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3471,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-126.json
+++ b/vulkan/profiles-0.8.1-126.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-126.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.126",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -552,6 +624,15 @@
                     "type": "boolean"
                 },
                 "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
                     "type": "boolean"
                 }
             }
@@ -604,11 +685,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +732,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +775,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +826,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1567,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1607,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1751,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1973,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2041,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2107,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2406,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2433,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2443,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2532,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2572,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2595,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2610,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2643,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2658,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2766,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2431,6 +2782,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
                             "VK_KHR_push_descriptor": {
@@ -2448,6 +2802,9 @@
                             "VK_KHR_shader_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_draw_parameters": {
                                 "type": "integer"
                             },
@@ -2457,7 +2814,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2829,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2893,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2952,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3001,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3022,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3037,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3072,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2692,23 +3094,68 @@
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3221,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3266,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3363,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3381,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3399,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3417,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3435,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3453,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3471,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-127.json
+++ b/vulkan/profiles-0.8.1-127.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-127.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.127",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -556,6 +628,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -592,6 +673,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -604,11 +694,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +741,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +784,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +835,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1576,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1616,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1553,6 +1760,15 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1766,6 +1982,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2050,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2116,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2415,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2442,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2452,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2541,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2581,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2604,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2619,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2652,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2667,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2775,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2433,6 +2793,9 @@
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
@@ -2445,7 +2808,13 @@
                             "VK_KHR_sampler_ycbcr_conversion": {
                                 "type": "integer"
                             },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_draw_parameters": {
@@ -2457,7 +2826,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2841,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2905,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2964,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3013,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3034,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3049,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3084,9 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2689,26 +3103,74 @@
                             "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
                             },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3236,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2816,14 +3281,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3378,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3396,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3414,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3432,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3450,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3468,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3486,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-128.json
+++ b/vulkan/profiles-0.8.1-128.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-128.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.128",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,15 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +384,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +490,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +514,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +564,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -556,6 +628,27 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -592,6 +685,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -604,11 +706,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +753,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +796,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +847,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1588,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1628,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1557,6 +1776,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceMaintenance3Properties": {
             "type": "object",
             "additionalProperties": false,
@@ -1663,6 +1891,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -1766,6 +2003,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2071,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2137,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2436,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2463,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2473,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2562,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2602,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2625,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2640,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2673,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2688,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2418,6 +2796,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2433,6 +2814,12 @@
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
@@ -2445,7 +2832,13 @@
                             "VK_KHR_sampler_ycbcr_conversion": {
                                 "type": "integer"
                             },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_draw_parameters": {
@@ -2457,7 +2850,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2865,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2929,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +2988,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3037,14 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3058,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3073,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3108,12 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2689,26 +3130,74 @@
                             "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
                             },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3263,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2794,6 +3286,9 @@
                             },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -2816,14 +3311,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3408,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3426,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3444,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3462,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3480,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3498,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3516,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-129.json
+++ b/vulkan/profiles-0.8.1-129.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-129.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.129",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,30 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +399,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +505,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +529,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +579,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -556,6 +643,27 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -592,6 +700,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -604,11 +721,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +768,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +811,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +862,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1603,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1643,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1557,6 +1791,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceMaintenance3Properties": {
             "type": "object",
             "additionalProperties": false,
@@ -1663,6 +1906,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -1766,6 +2018,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2086,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2152,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2451,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2478,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2488,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2577,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2617,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2640,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2655,16 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2688,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2703,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2335,6 +2728,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -2418,6 +2814,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2433,6 +2832,12 @@
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
@@ -2445,7 +2850,13 @@
                             "VK_KHR_sampler_ycbcr_conversion": {
                                 "type": "integer"
                             },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_draw_parameters": {
@@ -2457,7 +2868,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2883,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2947,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +3006,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3055,17 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3079,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3094,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3129,12 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2689,26 +3151,74 @@
                             "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
                             },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3284,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2794,6 +3307,9 @@
                             },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -2816,14 +3332,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3429,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3447,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3465,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3483,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3501,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3519,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3537,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-130.json
+++ b/vulkan/profiles-0.8.1-130.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-102.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.1.102",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-130.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.130",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -319,7 +319,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -330,6 +330,30 @@
                     "type": "boolean"
                 },
                 "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
                     "type": "boolean"
                 }
             }
@@ -375,6 +399,15 @@
             "additionalProperties": false,
             "properties": {
                 "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
                     "type": "boolean"
                 }
             }
@@ -472,18 +505,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderFloat16": {
-                    "type": "boolean"
-                },
-                "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -508,6 +529,48 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -516,6 +579,30 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
                     "type": "boolean"
                 }
             }
@@ -556,6 +643,27 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -592,6 +700,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -604,11 +721,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
                     "type": "boolean"
                 }
             }
@@ -618,6 +768,33 @@
             "additionalProperties": false,
             "properties": {
                 "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
                     "type": "boolean"
                 }
             }
@@ -634,6 +811,45 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -646,7 +862,16 @@
                 }
             }
         },
-        "VkPhysicalDeviceVariablePointerFeatures": {
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1378,7 +1603,9 @@
                 "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
                 "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
                 "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
@@ -1416,15 +1643,22 @@
                 }
             }
         },
+        "VkShaderFloatControlsIndependenceKHR": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
         "VkPhysicalDeviceFloatControlsPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "separateDenormSettings": {
-                    "type": "boolean"
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
-                "separateRoundingModeSettings": {
-                    "type": "boolean"
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependenceKHR"
                 },
                 "shaderDenormFlushToZeroFloat16": {
                     "type": "boolean"
@@ -1557,6 +1791,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
         "VkPhysicalDeviceMaintenance3Properties": {
             "type": "object",
             "additionalProperties": false,
@@ -1663,6 +1906,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -1766,6 +2018,30 @@
                 }
             }
         },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderCorePropertiesAMD": {
             "type": "object",
             "additionalProperties": false,
@@ -1810,6 +2086,18 @@
                     "$ref": "#/definitions/uint32_t"
                 },
                 "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -1864,6 +2152,51 @@
                 },
                 "supportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
                 }
             }
         },
@@ -2118,6 +2451,12 @@
                             "VK_AMD_buffer_marker": {
                                 "type": "integer"
                             },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
                             "VK_AMD_draw_indirect_count": {
                                 "type": "integer"
                             },
@@ -2139,6 +2478,9 @@
                             "VK_AMD_negative_viewport_height": {
                                 "type": "integer"
                             },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
                             "VK_AMD_rasterization_order": {
                                 "type": "integer"
                             },
@@ -2146,6 +2488,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -2232,16 +2577,34 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
                             "VK_EXT_global_priority": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
                             "VK_EXT_image_drm_format_modifier": {
                                 "type": "integer"
                             },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
                             "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -2254,6 +2617,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
@@ -2274,6 +2640,9 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -2286,7 +2655,19 @@
                             "VK_EXT_shader_viewport_index_layer": {
                                 "type": "integer"
                             },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
                             "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
                                 "type": "integer"
                             },
                             "VK_EXT_transform_feedback": {
@@ -2310,6 +2691,12 @@
                             "VK_FUCHSIA_imagepipe_surface": {
                                 "type": "integer"
                             },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
                             "VK_GOOGLE_decorate_string": {
                                 "type": "integer"
                             },
@@ -2319,10 +2706,19 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
                             "VK_IMG_filter_cubic": {
                                 "type": "integer"
                             },
                             "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
                                 "type": "integer"
                             },
                             "VK_KHR_16bit_storage": {
@@ -2335,6 +2731,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -2418,6 +2817,9 @@
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
                             "VK_KHR_incremental_present": {
                                 "type": "integer"
                             },
@@ -2433,6 +2835,12 @@
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
@@ -2445,7 +2853,13 @@
                             "VK_KHR_sampler_ycbcr_conversion": {
                                 "type": "integer"
                             },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_draw_parameters": {
@@ -2457,7 +2871,13 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
                             "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
                                 "type": "integer"
                             },
                             "VK_KHR_storage_buffer_storage_class": {
@@ -2466,10 +2886,19 @@
                             "VK_KHR_surface": {
                                 "type": "integer"
                             },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
                             "VK_KHR_swapchain": {
                                 "type": "integer"
                             },
                             "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
@@ -2521,6 +2950,9 @@
                                 "type": "integer"
                             },
                             "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
                                 "type": "integer"
                             },
                             "VK_NV_dedicated_allocation": {
@@ -2577,6 +3009,9 @@
                             "VK_NV_shader_image_footprint": {
                                 "type": "integer"
                             },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
                             "VK_NV_shader_subgroup_partitioned": {
                                 "type": "integer"
                             },
@@ -2623,8 +3058,17 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBufferAddressFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -2638,6 +3082,9 @@
                             "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
                             },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
@@ -2650,17 +3097,29 @@
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -2673,6 +3132,12 @@
                             },
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -2689,26 +3154,74 @@
                             "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
                             },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
                             },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR"
+                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeaturesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVariablePointerFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVariablePointerFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
                             },
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
@@ -2774,6 +3287,9 @@
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMaintenance3Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
@@ -2794,6 +3310,9 @@
                             },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -2816,14 +3335,29 @@
                             "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
                             },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
                             "VkPhysicalDeviceShadingRateImagePropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
                             },
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphorePropertiesKHR"
                             },
                             "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
@@ -2898,10 +3432,16 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
@@ -2910,10 +3450,16 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
@@ -2922,10 +3468,16 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
@@ -2934,10 +3486,16 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
@@ -2946,10 +3504,16 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
@@ -2958,10 +3522,16 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
@@ -2970,10 +3540,16 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {

--- a/vulkan/profiles-0.8.1-131.json
+++ b/vulkan/profiles-0.8.1-131.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-131.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.131",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,209 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +520,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +544,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +571,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +579,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +607,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +624,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1204,15 +651,6 @@
                     "type": "boolean"
                 },
                 "performanceCounterQueryPools": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineCreationCacheControl": {
                     "type": "boolean"
                 }
             }
@@ -1226,147 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,116 +673,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
-                    "type": "boolean"
-                },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                },
-                "rayTraversalPrimitiveCulling": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +709,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +733,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +751,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +759,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +772,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +799,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +811,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +819,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +891,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1084,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1099,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1558,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2730,25 +1619,16 @@
             "enum": [
                 "VK_SHADER_STAGE_ALL",
                 "VK_SHADER_STAGE_ALL_GRAPHICS",
-                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
-                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
                 "VK_SHADER_STAGE_CALLABLE_BIT_NV",
-                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
                 "VK_SHADER_STAGE_COMPUTE_BIT",
                 "VK_SHADER_STAGE_FRAGMENT_BIT",
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
-                "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
-                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1648,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2894,39 +1765,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxGraphicsShaderGroupCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenOffset": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectSequenceCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minIndirectCommandsBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesCountBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesIndexBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2964,7 +1802,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1812,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1837,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +1916,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +1925,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +1940,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +1979,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2018,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2076,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2094,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2124,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,15 +2141,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -3726,53 +2150,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePushDescriptorPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "maxPushDescriptors": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxRayDispatchInvocationCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayRecursionDepth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxShaderGroupStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleCaptureReplaySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -3804,18 +2186,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2299,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,150 +2684,8 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
-                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
@@ -4587,7 +2696,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2721,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2755,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2767,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2789,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,126 +2828,26 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
-                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
                 "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
                 "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
                 "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
-                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +2871,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +2933,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +2954,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +2969,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +2984,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +2993,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3003,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3017,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3024,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3035,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3044,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,79 +3053,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
-                            "VK_EXT_physical_device_drm": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_creation_cache_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pipeline_creation_feedback": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3080,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3096,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3125,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3146,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3167,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5546,16 +3176,10 @@
                             "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
-                            "VK_KHR_copy_commands2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_create_renderpass2": {
                                 "type": "integer"
                             },
                             "VK_KHR_dedicated_allocation": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_deferred_host_operations": {
                                 "type": "integer"
                             },
                             "VK_KHR_depth_stencil_resolve": {
@@ -5580,9 +3204,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3242,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3252,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3272,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5675,31 +3281,7 @@
                             "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3311,7 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_non_semantic_info": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3335,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3342,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3356,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3371,13 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
+                            "VK_NVX_device_generated_commands": {
                                 "type": "integer"
                             },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5855,19 +3404,10 @@
                             "VK_NV_device_diagnostic_checkpoints": {
                                 "type": "integer"
                             },
-                            "VK_NV_device_diagnostics_config": {
-                                "type": "integer"
-                            },
-                            "VK_NV_device_generated_commands": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_capabilities": {
-                                "type": "integer"
-                            },
-                            "VK_NV_external_memory_rdma": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_win32": {
@@ -5882,9 +3422,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3431,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5944,39 +3466,6 @@
                             },
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
-                            },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
-                                "type": "integer"
                             }
                         }
                     },
@@ -6000,9 +3489,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3498,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3516,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3531,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3543,23 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3570,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3588,17 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
-                            },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3618,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3627,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3645,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3660,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3702,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3714,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3733,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3741,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6565,9 +3754,6 @@
                             "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
                             },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
-                            },
                             "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
                             },
@@ -6576,12 +3762,6 @@
                             },
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
-                            },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
@@ -6592,26 +3772,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3781,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3793,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3805,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3817,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
-                            },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +3841,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +3850,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +3873,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +3920,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +3941,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +3948,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +3959,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +3966,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +3977,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +3984,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +3995,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4002,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4013,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4020,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4031,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4038,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4049,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4056,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4259,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4293,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4331,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4365,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4485,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4724,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-132.json
+++ b/vulkan/profiles-0.8.1-132.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-132.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.132",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,209 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +520,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +544,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +571,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +579,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +607,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +624,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1204,15 +651,6 @@
                     "type": "boolean"
                 },
                 "performanceCounterQueryPools": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineCreationCacheControl": {
                     "type": "boolean"
                 }
             }
@@ -1226,147 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,116 +673,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
-                    "type": "boolean"
-                },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                },
-                "rayTraversalPrimitiveCulling": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +709,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +733,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +751,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +759,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +772,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +799,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +811,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +819,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +891,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1084,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1099,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1558,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2730,25 +1619,16 @@
             "enum": [
                 "VK_SHADER_STAGE_ALL",
                 "VK_SHADER_STAGE_ALL_GRAPHICS",
-                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
-                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
                 "VK_SHADER_STAGE_CALLABLE_BIT_NV",
-                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
                 "VK_SHADER_STAGE_COMPUTE_BIT",
                 "VK_SHADER_STAGE_FRAGMENT_BIT",
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
-                "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
-                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1648,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2894,39 +1765,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxGraphicsShaderGroupCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenOffset": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectSequenceCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minIndirectCommandsBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesCountBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesIndexBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2964,7 +1802,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1812,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1837,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +1916,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +1925,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +1940,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +1979,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2018,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2076,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2094,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2124,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,15 +2141,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -3726,53 +2150,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePushDescriptorPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "maxPushDescriptors": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxRayDispatchInvocationCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayRecursionDepth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxShaderGroupStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleCaptureReplaySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -3804,18 +2186,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2299,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,150 +2684,8 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
-                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
@@ -4587,7 +2696,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2721,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2755,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2767,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2789,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,126 +2828,26 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
-                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
                 "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
                 "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
                 "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
-                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +2871,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +2933,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +2954,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +2969,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +2984,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +2993,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3003,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3017,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3024,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3035,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3044,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,79 +3053,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
-                            "VK_EXT_physical_device_drm": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_creation_cache_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pipeline_creation_feedback": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3080,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3096,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3125,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3146,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3167,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5546,16 +3176,10 @@
                             "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
-                            "VK_KHR_copy_commands2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_create_renderpass2": {
                                 "type": "integer"
                             },
                             "VK_KHR_dedicated_allocation": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_deferred_host_operations": {
                                 "type": "integer"
                             },
                             "VK_KHR_depth_stencil_resolve": {
@@ -5580,9 +3204,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3242,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3252,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3272,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5675,31 +3281,7 @@
                             "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3311,7 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_non_semantic_info": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3335,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3342,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3356,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3371,13 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
+                            "VK_NVX_device_generated_commands": {
                                 "type": "integer"
                             },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5855,19 +3404,10 @@
                             "VK_NV_device_diagnostic_checkpoints": {
                                 "type": "integer"
                             },
-                            "VK_NV_device_diagnostics_config": {
-                                "type": "integer"
-                            },
-                            "VK_NV_device_generated_commands": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_capabilities": {
-                                "type": "integer"
-                            },
-                            "VK_NV_external_memory_rdma": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_win32": {
@@ -5882,9 +3422,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3431,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5944,39 +3466,6 @@
                             },
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
-                            },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
-                                "type": "integer"
                             }
                         }
                     },
@@ -6000,9 +3489,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3498,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3516,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3531,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3543,23 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3570,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3588,17 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
-                            },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3618,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3627,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3645,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3660,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3702,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3714,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3733,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3741,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6565,9 +3754,6 @@
                             "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
                             },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
-                            },
                             "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
                             },
@@ -6576,12 +3762,6 @@
                             },
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
-                            },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
@@ -6592,26 +3772,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3781,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3793,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3805,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3817,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
-                            },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +3841,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +3850,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +3873,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +3920,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +3941,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +3948,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +3959,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +3966,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +3977,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +3984,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +3995,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4002,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4013,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4020,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4031,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4038,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4049,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4056,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4259,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4293,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4331,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4365,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4485,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4724,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-133.json
+++ b/vulkan/profiles-0.8.1-133.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-133.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.133",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,209 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +520,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +544,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +571,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +579,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +607,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +624,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1204,15 +651,6 @@
                     "type": "boolean"
                 },
                 "performanceCounterQueryPools": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineCreationCacheControl": {
                     "type": "boolean"
                 }
             }
@@ -1226,147 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,116 +673,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
-                    "type": "boolean"
-                },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                },
-                "rayTraversalPrimitiveCulling": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +709,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +733,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +751,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +759,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +772,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +799,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +811,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +819,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +891,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1084,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1099,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1558,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2730,25 +1619,16 @@
             "enum": [
                 "VK_SHADER_STAGE_ALL",
                 "VK_SHADER_STAGE_ALL_GRAPHICS",
-                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
-                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
                 "VK_SHADER_STAGE_CALLABLE_BIT_NV",
-                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
                 "VK_SHADER_STAGE_COMPUTE_BIT",
                 "VK_SHADER_STAGE_FRAGMENT_BIT",
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
-                "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
-                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1648,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2894,39 +1765,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxGraphicsShaderGroupCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenOffset": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectSequenceCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minIndirectCommandsBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesCountBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesIndexBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2964,7 +1802,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1812,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1837,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +1916,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +1925,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +1940,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +1979,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2018,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2076,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2094,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2124,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,15 +2141,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -3726,53 +2150,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePushDescriptorPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "maxPushDescriptors": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxRayDispatchInvocationCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayRecursionDepth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxShaderGroupStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleCaptureReplaySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -3804,18 +2186,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2299,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,150 +2684,8 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
-                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
@@ -4587,7 +2696,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2721,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2755,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2767,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2789,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,126 +2828,26 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
-                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
                 "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
                 "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
                 "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
-                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +2871,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +2933,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +2954,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +2969,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +2984,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +2993,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3003,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3017,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3024,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3035,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3044,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,79 +3053,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
-                            "VK_EXT_physical_device_drm": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_creation_cache_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pipeline_creation_feedback": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3080,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3096,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3125,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3146,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3167,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5546,16 +3176,10 @@
                             "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
-                            "VK_KHR_copy_commands2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_create_renderpass2": {
                                 "type": "integer"
                             },
                             "VK_KHR_dedicated_allocation": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_deferred_host_operations": {
                                 "type": "integer"
                             },
                             "VK_KHR_depth_stencil_resolve": {
@@ -5580,9 +3204,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3242,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3252,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3272,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5675,31 +3281,7 @@
                             "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3311,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3338,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3359,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3374,13 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
+                            "VK_NVX_device_generated_commands": {
                                 "type": "integer"
                             },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5855,19 +3407,10 @@
                             "VK_NV_device_diagnostic_checkpoints": {
                                 "type": "integer"
                             },
-                            "VK_NV_device_diagnostics_config": {
-                                "type": "integer"
-                            },
-                            "VK_NV_device_generated_commands": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_capabilities": {
-                                "type": "integer"
-                            },
-                            "VK_NV_external_memory_rdma": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_win32": {
@@ -5882,9 +3425,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3434,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5944,39 +3469,6 @@
                             },
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
-                            },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
-                                "type": "integer"
                             }
                         }
                     },
@@ -6000,9 +3492,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3501,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3519,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3534,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3546,23 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3573,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3591,17 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
-                            },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3621,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3630,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3648,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3663,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3705,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3717,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3736,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3744,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6565,9 +3757,6 @@
                             "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
                             },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
-                            },
                             "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
                             },
@@ -6576,12 +3765,6 @@
                             },
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
-                            },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
@@ -6592,26 +3775,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3784,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3796,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3808,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3820,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
-                            },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +3844,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +3853,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +3876,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +3923,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +3944,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +3951,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +3962,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +3969,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +3980,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +3987,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +3998,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4005,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4016,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4023,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4034,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4041,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4052,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4059,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4262,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4296,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4334,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4368,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4488,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4727,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-134.json
+++ b/vulkan/profiles-0.8.1-134.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-134.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.134",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,209 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +520,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +544,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +571,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +579,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +607,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +624,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1204,15 +651,6 @@
                     "type": "boolean"
                 },
                 "performanceCounterQueryPools": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineCreationCacheControl": {
                     "type": "boolean"
                 }
             }
@@ -1226,147 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,116 +673,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
-                    "type": "boolean"
-                },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                },
-                "rayTraversalPrimitiveCulling": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +709,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +733,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +751,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +759,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +772,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +799,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +811,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +819,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +891,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1084,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1099,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1558,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2730,25 +1619,16 @@
             "enum": [
                 "VK_SHADER_STAGE_ALL",
                 "VK_SHADER_STAGE_ALL_GRAPHICS",
-                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
-                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
                 "VK_SHADER_STAGE_CALLABLE_BIT_NV",
-                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
                 "VK_SHADER_STAGE_COMPUTE_BIT",
                 "VK_SHADER_STAGE_FRAGMENT_BIT",
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
-                "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
-                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1648,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2894,39 +1765,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxGraphicsShaderGroupCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenOffset": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectSequenceCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minIndirectCommandsBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesCountBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesIndexBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2964,7 +1802,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1812,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1837,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +1916,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +1925,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +1940,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +1979,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2018,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2076,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2094,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2124,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,15 +2141,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -3726,53 +2150,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePushDescriptorPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "maxPushDescriptors": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxRayDispatchInvocationCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayRecursionDepth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxShaderGroupStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleCaptureReplaySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -3804,18 +2186,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2299,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,150 +2684,8 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
-                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
@@ -4587,7 +2696,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2721,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2755,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2767,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2789,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,126 +2828,26 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
-                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
                 "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
                 "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
                 "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
-                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +2871,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +2933,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +2954,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +2969,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +2984,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +2993,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3003,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3017,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3024,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3035,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3044,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,79 +3053,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
-                            "VK_EXT_physical_device_drm": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_creation_cache_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pipeline_creation_feedback": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3080,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3096,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3125,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3146,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3167,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5546,16 +3176,10 @@
                             "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
-                            "VK_KHR_copy_commands2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_create_renderpass2": {
                                 "type": "integer"
                             },
                             "VK_KHR_dedicated_allocation": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_deferred_host_operations": {
                                 "type": "integer"
                             },
                             "VK_KHR_depth_stencil_resolve": {
@@ -5580,9 +3204,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3242,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3252,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3272,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5675,31 +3281,7 @@
                             "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3311,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3338,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3359,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3374,13 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
+                            "VK_NVX_device_generated_commands": {
                                 "type": "integer"
                             },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5855,19 +3407,10 @@
                             "VK_NV_device_diagnostic_checkpoints": {
                                 "type": "integer"
                             },
-                            "VK_NV_device_diagnostics_config": {
-                                "type": "integer"
-                            },
-                            "VK_NV_device_generated_commands": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_capabilities": {
-                                "type": "integer"
-                            },
-                            "VK_NV_external_memory_rdma": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_win32": {
@@ -5882,9 +3425,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3434,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,37 +3470,7 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3495,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3504,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3522,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3537,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3549,23 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3576,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3594,17 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
-                            },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3624,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3633,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3651,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3666,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3708,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3720,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3739,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3747,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6565,9 +3760,6 @@
                             "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
                             },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
-                            },
                             "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
                             },
@@ -6576,12 +3768,6 @@
                             },
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
-                            },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
@@ -6592,26 +3778,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3787,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3799,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3811,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3823,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
-                            },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +3847,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +3856,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +3879,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +3926,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +3947,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +3954,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +3965,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +3972,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +3983,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +3990,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4001,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4008,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4019,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4026,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4037,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4044,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4055,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4062,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4265,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4299,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4337,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4371,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4491,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4730,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-135.json
+++ b/vulkan/profiles-0.8.1-135.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-135.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.135",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,209 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +520,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +544,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +571,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +579,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +607,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +624,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1204,15 +651,6 @@
                     "type": "boolean"
                 },
                 "performanceCounterQueryPools": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineCreationCacheControl": {
                     "type": "boolean"
                 }
             }
@@ -1226,147 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,116 +673,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
-                    "type": "boolean"
-                },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
-                    "type": "boolean"
-                },
-                "rayTracingPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                },
-                "rayTraversalPrimitiveCulling": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +709,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +733,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +751,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +759,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +772,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +799,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +811,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +819,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +891,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1084,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1099,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1558,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2730,25 +1619,16 @@
             "enum": [
                 "VK_SHADER_STAGE_ALL",
                 "VK_SHADER_STAGE_ALL_GRAPHICS",
-                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
-                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
                 "VK_SHADER_STAGE_CALLABLE_BIT_NV",
-                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
                 "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
                 "VK_SHADER_STAGE_COMPUTE_BIT",
                 "VK_SHADER_STAGE_FRAGMENT_BIT",
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
-                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
-                "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
-                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1648,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2894,39 +1765,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxGraphicsShaderGroupCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsStreamStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectCommandsTokenOffset": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxIndirectSequenceCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minIndirectCommandsBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesCountBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSequencesIndexBufferOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2964,7 +1802,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1812,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1837,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +1916,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +1925,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +1940,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +1979,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2018,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2076,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2094,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2124,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,15 +2141,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -3726,53 +2150,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePushDescriptorPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "maxPushDescriptors": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxRayDispatchInvocationCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxRayRecursionDepth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxShaderGroupStride": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleCaptureReplaySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
                 }
             }
@@ -3804,18 +2186,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2299,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,150 +2684,8 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
-                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
@@ -4587,7 +2696,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2721,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2755,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2767,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2789,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,126 +2828,26 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
-                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
                 "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
                 "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
                 "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
-                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +2871,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +2933,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +2954,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +2969,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +2984,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +2993,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3003,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3017,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3024,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3035,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3044,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,79 +3053,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
                                 "type": "integer"
                             },
                             "VK_EXT_pci_bus_info": {
                                 "type": "integer"
                             },
-                            "VK_EXT_physical_device_drm": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_creation_cache_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pipeline_creation_feedback": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
                                 "type": "integer"
                             },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3080,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3096,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3125,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3146,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3167,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5546,16 +3176,10 @@
                             "VK_KHR_buffer_device_address": {
                                 "type": "integer"
                             },
-                            "VK_KHR_copy_commands2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_create_renderpass2": {
                                 "type": "integer"
                             },
                             "VK_KHR_dedicated_allocation": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_deferred_host_operations": {
                                 "type": "integer"
                             },
                             "VK_KHR_depth_stencil_resolve": {
@@ -5580,9 +3204,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3242,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3252,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3272,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5675,31 +3281,7 @@
                             "VK_KHR_pipeline_executable_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3311,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3338,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3359,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3374,13 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
+                            "VK_NVX_device_generated_commands": {
                                 "type": "integer"
                             },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5855,19 +3407,10 @@
                             "VK_NV_device_diagnostic_checkpoints": {
                                 "type": "integer"
                             },
-                            "VK_NV_device_diagnostics_config": {
-                                "type": "integer"
-                            },
-                            "VK_NV_device_generated_commands": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_capabilities": {
-                                "type": "integer"
-                            },
-                            "VK_NV_external_memory_rdma": {
                                 "type": "integer"
                             },
                             "VK_NV_external_memory_win32": {
@@ -5882,9 +3425,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3434,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,37 +3470,7 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3495,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3504,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3522,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3537,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3549,23 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3576,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3594,17 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
-                            },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3624,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3633,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3651,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3666,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3708,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3720,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3739,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3747,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6565,9 +3760,6 @@
                             "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
                             },
-                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
-                            },
                             "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
                             },
@@ -6576,12 +3768,6 @@
                             },
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
-                            },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
@@ -6592,26 +3778,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3787,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3799,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3811,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3823,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
-                            },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +3847,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +3856,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +3879,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +3926,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +3947,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +3954,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +3965,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +3972,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +3983,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +3990,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4001,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4008,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4019,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4026,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4037,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4044,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4055,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4062,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4265,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4299,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4337,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4371,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4491,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4730,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-136.json
+++ b/vulkan/profiles-0.8.1-136.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-136.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.136",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,29 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
                     "type": "boolean"
                 }
             }
@@ -632,173 +514,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +538,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +562,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +597,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +625,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +642,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +661,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1208,7 +673,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1226,147 +691,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,92 +700,35 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
                     "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
+                },
+                "rayTracing": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
+                "rayTracingAccelerationStructureCaptureReplay": {
                     "type": "boolean"
                 },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
+                "rayTracingHostAccelerationStructureCommands": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                "rayTracingIndirectAccelerationStructureBuild": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                "rayTracingIndirectTraceRays": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect": {
+                "rayTracingPrimitiveCulling": {
                     "type": "boolean"
                 },
-                "rayTraversalPrimitiveCulling": {
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
                     "type": "boolean"
                 }
             }
@@ -1471,21 +738,6 @@
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +769,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +793,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +811,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +819,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +859,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +879,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +892,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +951,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1144,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1159,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2741,14 +1690,11 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1714,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2964,7 +1901,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1911,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1936,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +2015,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +2024,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +2039,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +2078,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2117,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2175,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2193,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2223,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,32 +2240,11 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "protectedNoFault": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
                     "type": "boolean"
                 }
             }
@@ -3747,26 +2258,29 @@
                 }
             }
         },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "maxRayDispatchInvocationCount": {
+                "maxDescriptorSetAccelerationStructures": {
                     "$ref": "#/definitions/uint32_t"
                 },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
                 },
-                "maxRayRecursionDepth": {
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxShaderGroupStride": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupHandleCaptureReplaySize": {
@@ -3804,18 +2318,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2431,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2496,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2514,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,147 +2816,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4587,7 +2829,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2854,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2888,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2900,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2922,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,99 +2961,6 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
@@ -4948,18 +2976,13 @@
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +3006,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +3068,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +3089,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +3104,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +3119,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +3128,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3138,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3152,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3159,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3170,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3179,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,37 +3188,10 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pci_bus_info": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_physical_device_drm": {
                                 "type": "integer"
                             },
                             "VK_EXT_pipeline_creation_cache_control": {
@@ -5348,40 +3200,10 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
-                                "type": "integer"
-                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3218,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3234,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3263,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3284,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3305,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5544,9 +3312,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_buffer_device_address": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_copy_commands2": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -5580,9 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3383,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3393,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3413,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5678,28 +3425,10 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
+                            "VK_KHR_ray_tracing": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3458,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3485,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3492,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3506,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3521,10 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
-                                "type": "integer"
-                            },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5867,9 +3563,6 @@
                             "VK_NV_external_memory_capabilities": {
                                 "type": "integer"
                             },
-                            "VK_NV_external_memory_rdma": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory_win32": {
                                 "type": "integer"
                             },
@@ -5882,9 +3575,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3584,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,37 +3620,7 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_store_ops": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3645,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3654,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3672,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3687,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3699,29 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3732,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3750,23 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
                             },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3786,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3795,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3813,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3828,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3870,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3882,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3901,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3909,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6577,12 +3934,6 @@
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
                             },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
-                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -6592,26 +3943,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3952,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3964,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3976,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3988,17 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
                             },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +4015,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +4024,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +4047,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +4094,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +4115,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +4122,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +4133,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +4140,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +4151,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +4158,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4169,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4176,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4187,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4194,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4205,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4212,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4223,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4230,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4433,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4467,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4505,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4539,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4659,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4898,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-137.json
+++ b/vulkan/profiles-0.8.1-137.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-137.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.137",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,29 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
                     "type": "boolean"
                 }
             }
@@ -632,173 +514,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +538,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +562,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +597,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +625,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +642,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +661,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1208,7 +673,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1226,147 +691,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,92 +700,35 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
                     "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
+                },
+                "rayTracing": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
+                "rayTracingAccelerationStructureCaptureReplay": {
                     "type": "boolean"
                 },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
+                "rayTracingHostAccelerationStructureCommands": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                "rayTracingIndirectAccelerationStructureBuild": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                "rayTracingIndirectTraceRays": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect": {
+                "rayTracingPrimitiveCulling": {
                     "type": "boolean"
                 },
-                "rayTraversalPrimitiveCulling": {
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
                     "type": "boolean"
                 }
             }
@@ -1471,21 +738,6 @@
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +769,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +793,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +811,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +819,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +859,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +879,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +892,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +951,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1144,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1159,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2741,14 +1690,11 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1714,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2964,7 +1901,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1911,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1936,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +2015,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +2024,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +2039,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +2078,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2117,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2175,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2193,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2223,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,32 +2240,11 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "protectedNoFault": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
                     "type": "boolean"
                 }
             }
@@ -3747,26 +2258,29 @@
                 }
             }
         },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "maxRayDispatchInvocationCount": {
+                "maxDescriptorSetAccelerationStructures": {
                     "$ref": "#/definitions/uint32_t"
                 },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
                 },
-                "maxRayRecursionDepth": {
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxShaderGroupStride": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupHandleCaptureReplaySize": {
@@ -3804,18 +2318,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2431,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2496,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2514,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,147 +2816,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4587,7 +2829,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2854,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2888,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2900,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2922,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,99 +2961,6 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
@@ -4948,18 +2976,13 @@
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +3006,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +3068,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +3089,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +3104,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +3119,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +3128,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3138,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3152,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3159,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3170,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3179,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,37 +3188,10 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pci_bus_info": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_physical_device_drm": {
                                 "type": "integer"
                             },
                             "VK_EXT_pipeline_creation_cache_control": {
@@ -5348,40 +3200,10 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
-                                "type": "integer"
-                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3218,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3234,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3263,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3284,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3305,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5544,9 +3312,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_buffer_device_address": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_copy_commands2": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -5580,9 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3383,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3393,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3413,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5678,28 +3425,10 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
+                            "VK_KHR_ray_tracing": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3458,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3485,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3492,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3506,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3521,10 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
-                                "type": "integer"
-                            },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5867,9 +3563,6 @@
                             "VK_NV_external_memory_capabilities": {
                                 "type": "integer"
                             },
-                            "VK_NV_external_memory_rdma": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory_win32": {
                                 "type": "integer"
                             },
@@ -5882,9 +3575,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3584,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,37 +3620,10 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_store_ops": {
                                 "type": "integer"
                             },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3648,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3657,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3675,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3690,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3702,29 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3735,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3753,23 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
                             },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3789,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3798,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3816,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3831,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3873,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3885,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3904,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3912,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6577,12 +3937,6 @@
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
                             },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
-                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -6592,26 +3946,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3955,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3967,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3979,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3991,17 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
                             },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +4018,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +4027,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +4050,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +4097,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +4118,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +4125,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +4136,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +4143,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +4154,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +4161,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4172,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4179,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4190,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4197,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4208,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4215,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4226,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4233,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4436,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4470,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4508,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4542,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4662,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4901,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-138.json
+++ b/vulkan/profiles-0.8.1-138.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-138.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.138",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,29 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
                     "type": "boolean"
                 }
             }
@@ -632,173 +514,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +538,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +562,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +597,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +625,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +642,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +661,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1208,7 +673,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1226,147 +691,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,92 +700,35 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
                     "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
+                },
+                "rayTracing": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
+                "rayTracingAccelerationStructureCaptureReplay": {
                     "type": "boolean"
                 },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
+                "rayTracingHostAccelerationStructureCommands": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                "rayTracingIndirectAccelerationStructureBuild": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                "rayTracingIndirectTraceRays": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect": {
+                "rayTracingPrimitiveCulling": {
                     "type": "boolean"
                 },
-                "rayTraversalPrimitiveCulling": {
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
                     "type": "boolean"
                 }
             }
@@ -1471,21 +738,6 @@
             "additionalProperties": false,
             "properties": {
                 "representativeFragmentTest": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nullDescriptor": {
-                    "type": "boolean"
-                },
-                "robustBufferAccess2": {
-                    "type": "boolean"
-                },
-                "robustImageAccess2": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +769,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +793,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +811,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +819,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +832,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +859,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +879,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +892,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +951,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1144,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1159,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2741,14 +1690,11 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1714,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2964,7 +1901,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1911,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1936,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +2015,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +2024,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +2039,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +2078,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2117,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2175,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2193,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2223,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,32 +2240,11 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "protectedNoFault": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
                     "type": "boolean"
                 }
             }
@@ -3747,26 +2258,29 @@
                 }
             }
         },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "maxRayDispatchInvocationCount": {
+                "maxDescriptorSetAccelerationStructures": {
                     "$ref": "#/definitions/uint32_t"
                 },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
                 },
-                "maxRayRecursionDepth": {
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxShaderGroupStride": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupHandleCaptureReplaySize": {
@@ -3804,18 +2318,6 @@
                 },
                 "shaderGroupHandleSize": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceRobustness2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustStorageBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "robustUniformBufferAccessSizeAlignment": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3929,116 +2431,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2496,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2514,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,147 +2816,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4587,7 +2829,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2854,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2888,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2900,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2922,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,99 +2961,6 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
@@ -4948,18 +2976,13 @@
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +3006,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +3068,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +3089,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +3104,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +3119,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +3128,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3138,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3152,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3159,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3170,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3179,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,37 +3188,10 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pci_bus_info": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_physical_device_drm": {
                                 "type": "integer"
                             },
                             "VK_EXT_pipeline_creation_cache_control": {
@@ -5348,40 +3200,10 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
-                                "type": "integer"
-                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_robustness2": {
                                 "type": "integer"
                             },
                             "VK_EXT_sample_locations": {
@@ -5396,19 +3218,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3234,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3263,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3284,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3305,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5544,9 +3312,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_buffer_device_address": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_copy_commands2": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -5580,9 +3345,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3383,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3393,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3413,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5678,28 +3425,10 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
+                            "VK_KHR_ray_tracing": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3458,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3485,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3492,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3506,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3521,10 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
-                                "type": "integer"
-                            },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5867,9 +3563,6 @@
                             "VK_NV_external_memory_capabilities": {
                                 "type": "integer"
                             },
-                            "VK_NV_external_memory_rdma": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory_win32": {
                                 "type": "integer"
                             },
@@ -5882,9 +3575,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3584,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,37 +3620,10 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_render_pass_shader_resolve": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_store_ops": {
                                 "type": "integer"
                             },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3648,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3657,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3675,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3690,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3702,29 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3735,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,101 +3753,23 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
                             },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
                             },
                             "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
@@ -6351,12 +3789,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3798,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3816,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3831,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3873,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3885,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3904,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3912,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6577,12 +3937,6 @@
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
                             },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
-                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -6592,26 +3946,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3955,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +3967,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +3979,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,26 +3991,17 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
                             },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
-                            },
-                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
                             },
                             "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
@@ -6718,15 +4018,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +4027,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +4050,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +4097,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +4118,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +4125,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +4136,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +4143,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +4154,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +4161,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4172,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4179,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4190,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4197,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4208,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4215,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4226,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4233,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4436,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4470,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4508,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4542,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4662,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4901,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-139.json
+++ b/vulkan/profiles-0.8.1-139.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-139.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.139",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -482,41 +412,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "customBorderColorWithoutFormat": {
-                    "type": "boolean"
-                },
-                "customBorderColors": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
                     "type": "boolean"
                 }
             }
@@ -596,29 +496,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
                     "type": "boolean"
                 }
             }
@@ -632,173 +514,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +538,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +562,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +597,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +625,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +642,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +661,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1208,7 +673,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1226,147 +691,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,92 +700,35 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
                     "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
+                },
+                "rayTracing": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
+                "rayTracingAccelerationStructureCaptureReplay": {
                     "type": "boolean"
                 },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
+                "rayTracingHostAccelerationStructureCommands": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                "rayTracingIndirectAccelerationStructureBuild": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                "rayTracingIndirectTraceRays": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect": {
+                "rayTracingPrimitiveCulling": {
                     "type": "boolean"
                 },
-                "rayTraversalPrimitiveCulling": {
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +784,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +808,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +826,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +834,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +847,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +874,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +886,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +894,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +907,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +966,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1159,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1174,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1633,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2741,14 +1705,11 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2768,15 +1729,6 @@
             "properties": {
                 "cooperativeMatrixSupportedStages": {
                     "$ref": "#/definitions/VkShaderStageFlags"
-                }
-            }
-        },
-        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxCustomBorderColorSamplers": {
-                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2964,7 +1916,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1926,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1951,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +2030,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +2039,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +2054,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +2093,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2132,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2190,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2208,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2238,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,32 +2255,11 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "protectedNoFault": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
                     "type": "boolean"
                 }
             }
@@ -3747,26 +2273,29 @@
                 }
             }
         },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "maxRayDispatchInvocationCount": {
+                "maxDescriptorSetAccelerationStructures": {
                     "$ref": "#/definitions/uint32_t"
                 },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
                 },
-                "maxRayRecursionDepth": {
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxShaderGroupStride": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupHandleCaptureReplaySize": {
@@ -3929,116 +2458,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2523,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2541,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,147 +2843,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4587,7 +2856,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2881,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2915,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2927,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2949,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,99 +2988,6 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
@@ -4948,18 +3003,13 @@
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +3033,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +3095,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,28 +3116,13 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -5162,16 +3131,10 @@
                             "VK_EXT_calibrated_timestamps": {
                                 "type": "integer"
                             },
-                            "VK_EXT_color_write_enable": {
-                                "type": "integer"
-                            },
                             "VK_EXT_conditional_rendering": {
                                 "type": "integer"
                             },
                             "VK_EXT_conservative_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_custom_border_color": {
                                 "type": "integer"
                             },
                             "VK_EXT_debug_marker": {
@@ -5183,12 +3146,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +3155,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3165,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3179,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3186,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3197,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3206,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,37 +3215,10 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pci_bus_info": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_physical_device_drm": {
                                 "type": "integer"
                             },
                             "VK_EXT_pipeline_creation_cache_control": {
@@ -5348,37 +3227,10 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
-                                "type": "integer"
-                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_private_data": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -5396,19 +3248,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3264,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3293,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3314,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3335,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5544,9 +3342,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_buffer_device_address": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_copy_commands2": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -5580,9 +3375,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3413,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3423,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3443,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5678,28 +3455,10 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
+                            "VK_KHR_ray_tracing": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3488,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3515,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3522,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3536,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3551,10 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
-                                "type": "integer"
-                            },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5867,9 +3593,6 @@
                             "VK_NV_external_memory_capabilities": {
                                 "type": "integer"
                             },
-                            "VK_NV_external_memory_rdma": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory_win32": {
                                 "type": "integer"
                             },
@@ -5882,9 +3605,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3614,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,12 +3650,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5958,24 +3657,6 @@
                                 "type": "integer"
                             },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3681,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3690,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6045,9 +3708,6 @@
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
                             },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
-                            },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
                             },
@@ -6063,17 +3723,8 @@
                             "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
                             },
-                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
@@ -6084,101 +3735,29 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3768,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,95 +3786,20 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
                             },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
@@ -6351,12 +3825,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3834,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3852,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3867,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3909,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3921,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6538,9 +3940,6 @@
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
                             },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
                             },
@@ -6549,9 +3948,6 @@
                             },
                             "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
-                            },
-                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
                             },
                             "VkPhysicalDeviceDepthStencilResolveProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
@@ -6577,12 +3973,6 @@
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
                             },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
-                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -6592,26 +3982,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +3991,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +4003,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +4015,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,20 +4027,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
                             },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
@@ -6718,15 +4057,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +4066,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +4089,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +4136,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +4157,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +4164,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +4175,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +4182,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +4193,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +4200,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4211,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4218,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4229,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4236,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4247,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4254,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4265,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4272,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4475,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4509,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4547,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4581,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4701,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4940,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-140.json
+++ b/vulkan/profiles-0.8.1-140.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8-latest.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-140.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.140",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,15 +57,27 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "type": "integer"
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "uint64_t": {
-            "type": "integer",
-            "minimum": 0
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         },
         "VkDeviceSize": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint64_t"
         },
         "char": {
             "type": "string"
@@ -74,8 +86,7 @@
             "type": "number"
         },
         "size_t": {
-            "type": "integer",
-            "minimum": 0
+            "$ref": "#/definitions/uint32_t"
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -275,18 +286,6 @@
                 }
             }
         },
-        "VkPhysicalDevice4444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatA4B4G4R4": {
-                    "type": "boolean"
-                },
-                "formatA4R4G4B4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevice8BitStorageFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -311,71 +310,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "accelerationStructure": {
-                    "type": "boolean"
-                },
-                "accelerationStructureCaptureReplay": {
-                    "type": "boolean"
-                },
-                "accelerationStructureHostCommands": {
-                    "type": "boolean"
-                },
-                "accelerationStructureIndirectBuild": {
-                    "type": "boolean"
-                },
-                "descriptorBindingAccelerationStructureUpdateAfterBind": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "reportAddressBinding": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "amigoProfiling": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFeedbackLoopLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "advancedBlendCoherentOperations": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
                     "type": "boolean"
                 }
             }
@@ -415,15 +354,6 @@
             "additionalProperties": false,
             "properties": {
                 "deviceCoherentMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "colorWriteEnable": {
                     "type": "boolean"
                 }
             }
@@ -503,24 +433,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClampZeroOne": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -596,29 +508,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "deviceGeneratedCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceMemoryReport": {
                     "type": "boolean"
                 }
             }
@@ -632,173 +526,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclusiveScissor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState2": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2LogicOp": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState2PatchControlPoints": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState3AlphaToCoverageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3AlphaToOneEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendAdvanced": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorBlendEquation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ColorWriteMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ConservativeRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageModulationTableEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageReductionMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3CoverageToColorLocation": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClampEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3DepthClipNegativeOneToOne": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineRasterizationMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LineStippleEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3LogicOpEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3PolygonMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ProvokingVertexMode": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationSamples": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RasterizationStream": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3RepresentativeFragmentTestEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleLocationsEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3SampleMask": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ShadingRateImageEnable": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3TessellationDomainOrigin": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportSwizzle": {
-                    "type": "boolean"
-                },
-                "extendedDynamicState3ViewportWScalingEnable": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extendedDynamicState": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "externalMemoryRDMA": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFaultFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "deviceFault": {
-                    "type": "boolean"
-                },
-                "deviceFaultVendorBinary": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapDeferred": {
                     "type": "boolean"
                 }
             }
@@ -818,16 +550,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -851,122 +574,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateEnums": {
-                    "type": "boolean"
-                },
-                "noInvocationFragmentShadingRates": {
-                    "type": "boolean"
-                },
-                "supersampleFragmentShadingRates": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "attachmentFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "pipelineFragmentShadingRate": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRate": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "globalPriorityQuery": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibrary": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "image2DViewOf3D": {
-                    "type": "boolean"
-                },
-                "sampler2DViewOf3D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "imageCompressionControlSwapchain": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "textureBlockMatch": {
-                    "type": "boolean"
-                },
-                "textureBoxFilter": {
-                    "type": "boolean"
-                },
-                "textureSampleWeighted": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -989,16 +601,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "inheritedViewportScissor2D": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1006,24 +609,6 @@
                     "type": "boolean"
                 },
                 "inlineUniformBlock": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "invocationMask": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "legacyDithering": {
                     "type": "boolean"
                 }
             }
@@ -1052,50 +637,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "memoryPriority": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "meshShader": {
-                    "type": "boolean"
-                },
-                "meshShaderQueries": {
-                    "type": "boolean"
-                },
-                "multiviewMeshShader": {
-                    "type": "boolean"
-                },
-                "primitiveFragmentShadingRateMeshShader": {
-                    "type": "boolean"
-                },
-                "taskShader": {
                     "type": "boolean"
                 }
             }
@@ -1108,24 +654,6 @@
                     "type": "boolean"
                 },
                 "taskShader": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multiDraw": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -1145,57 +673,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "mutableDescriptorType": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "nonSeamlessCubeMap": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "micromap": {
-                    "type": "boolean"
-                },
-                "micromapCaptureReplay": {
-                    "type": "boolean"
-                },
-                "micromapHostCommands": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "opticalFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pageableDeviceLocalMemory": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1208,7 +685,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1226,147 +703,6 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelinePropertiesIdentifier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineProtectedAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pipelineRobustness": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "constantAlphaColorBlendFactors": {
-                    "type": "boolean"
-                },
-                "events": {
-                    "type": "boolean"
-                },
-                "imageView2DOn3DImage": {
-                    "type": "boolean"
-                },
-                "imageViewFormatReinterpretation": {
-                    "type": "boolean"
-                },
-                "imageViewFormatSwizzle": {
-                    "type": "boolean"
-                },
-                "multisampleArrayImage": {
-                    "type": "boolean"
-                },
-                "mutableComparisonSamplers": {
-                    "type": "boolean"
-                },
-                "pointPolygons": {
-                    "type": "boolean"
-                },
-                "samplerMipLodBias": {
-                    "type": "boolean"
-                },
-                "separateStencilMaskRef": {
-                    "type": "boolean"
-                },
-                "shaderSampleRateInterpolationFunctions": {
-                    "type": "boolean"
-                },
-                "tessellationIsolines": {
-                    "type": "boolean"
-                },
-                "tessellationPointMode": {
-                    "type": "boolean"
-                },
-                "triangleFans": {
-                    "type": "boolean"
-                },
-                "vertexAttributeAccessBeyondStride": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentBarrierFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentBarrier": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentIdFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentId": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePresentWaitFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "presentWait": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitiveTopologyListRestart": {
-                    "type": "boolean"
-                },
-                "primitiveTopologyPatchListRestart": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "primitivesGeneratedQuery": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithNonZeroStreams": {
-                    "type": "boolean"
-                },
-                "primitivesGeneratedQueryWithRasterizerDiscard": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDevicePrivateDataFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "privateData": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1376,92 +712,35 @@
                 }
             }
         },
-        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexLast": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
                     "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMaintenance1": {
+                },
+                "rayTracing": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingMotionBlur": {
+                "rayTracingAccelerationStructureCaptureReplay": {
                     "type": "boolean"
                 },
-                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rayTracingPipeline": {
+                "rayTracingHostAccelerationStructureCommands": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                "rayTracingIndirectAccelerationStructureBuild": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                "rayTracingIndirectTraceRays": {
                     "type": "boolean"
                 },
-                "rayTracingPipelineTraceRaysIndirect": {
+                "rayTracingPrimitiveCulling": {
                     "type": "boolean"
                 },
-                "rayTraversalPrimitiveCulling": {
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
                     "type": "boolean"
                 }
             }
@@ -1517,90 +796,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat16Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicMinMax": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicMinMax": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderBufferFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderBufferFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderImageFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat32Atomics": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64AtomicAdd": {
-                    "type": "boolean"
-                },
-                "shaderSharedFloat64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32AtomicAdd": {
-                    "type": "boolean"
-                },
-                "sparseImageFloat32Atomics": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderAtomicInt64Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1625,7 +820,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1643,15 +838,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderEarlyAndLateFragmentTests": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1660,18 +846,6 @@
                     "type": "boolean"
                 },
                 "shaderInt8": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderImageInt64Atomics": {
-                    "type": "boolean"
-                },
-                "sparseImageInt64Atomics": {
                     "type": "boolean"
                 }
             }
@@ -1685,29 +859,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1730,24 +886,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderSubgroupUniformControlFlow": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceShadingRateImageFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -1760,7 +898,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1768,33 +906,6 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassMergeFeedback": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "subpassShading": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceSynchronization2Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "synchronization2": {
                     "type": "boolean"
                 }
             }
@@ -1808,20 +919,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -1876,15 +978,6 @@
                     "type": "boolean"
                 },
                 "vertexAttributeInstanceRateZeroDivisor": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "vertexInputDynamicState": {
                     "type": "boolean"
                 }
             }
@@ -2078,57 +1171,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -2144,47 +1186,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "workgroupMemoryExplicitLayout": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout16BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayout8BitAccess": {
-                    "type": "boolean"
-                },
-                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "ycbcr2plane444Formats": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "ycbcrImageArrays": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderZeroInitializeWorkgroupMemory": {
                     "type": "boolean"
                 }
             }
@@ -2639,36 +1645,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxGeometryCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxInstanceCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "maxPerStageDescriptorAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPrimitiveCount": {
-                    "$ref": "#/definitions/uint64_t"
-                },
-                "minAccelerationStructureScratchOffsetAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2741,14 +1717,11 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
-                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
-                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2964,7 +1937,6 @@
                 "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
                 "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY",
                 "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
@@ -2975,22 +1947,12 @@
                 "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
-                "VK_DRIVER_ID_JUICE_PROPRIETARY",
-                "VK_DRIVER_ID_MESA_DOZEN",
-                "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
-                "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
-                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
-                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
             ]
         },
         "VkPhysicalDeviceDriverProperties": {
@@ -3010,39 +1972,6 @@
                 "driverName": {
                     "type": "string",
                     "maxLength": 255
-                }
-            }
-        },
-        "VkPhysicalDeviceDrmPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "hasPrimary": {
-                    "type": "boolean"
-                },
-                "hasRender": {
-                    "type": "boolean"
-                },
-                "primaryMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "primaryMinor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMajor": {
-                    "$ref": "#/definitions/int64_t"
-                },
-                "renderMinor": {
-                    "$ref": "#/definitions/int64_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicPrimitiveTopologyUnrestricted": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3122,24 +2051,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxDescriptorSetSubsampledSamplers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubsampledArrayLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "subsampledCoarseReconstructionEarlyAccess": {
-                    "type": "boolean"
-                },
-                "subsampledLoads": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkExtent2D": {
             "type": "object",
             "additionalProperties": false,
@@ -3149,15 +2060,6 @@
                 },
                 "width": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
                 }
             }
         },
@@ -3173,93 +2075,6 @@
                 },
                 "minFragmentDensityTexelSize": {
                     "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "triStripVertexOrderIndependentOfProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxFragmentShadingRateInvocationCount": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                }
-            }
-        },
-        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentShadingRateNonTrivialCombinerOps": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateStrictMultiplyCombiner": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithConservativeRasterization": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithCustomSampleLocations": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithFragmentShaderInterlock": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithSampleMask": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderDepthStencilWrites": {
-                    "type": "boolean"
-                },
-                "fragmentShadingRateWithShaderSampleMask": {
-                    "type": "boolean"
-                },
-                "layeredShadingRateAttachments": {
-                    "type": "boolean"
-                },
-                "maxFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateCoverageSamples": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxFragmentShadingRateRasterizationSamples": {
-                    "$ref": "#/definitions/VkSampleCountFlagBits"
-                },
-                "maxFragmentSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxFragmentSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minFragmentShadingRateAttachmentTexelSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "primitiveFragmentShadingRateWithMultipleViewports": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "graphicsPipelineLibraryFastLinking": {
-                    "type": "boolean"
-                },
-                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3299,25 +2114,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBlockMatchRegion": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxBoxFilterBlockSize": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterDimension": {
-                    "$ref": "#/definitions/VkExtent2D"
-                },
-                "maxWeightFilterPhases": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3356,125 +2153,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                }
-            }
-        },
-        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMeshMultiviewViewCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputComponents": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputLayers": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputPrimitives": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshOutputVertices": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndOutputMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxMeshWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxMeshWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredMeshWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPreferredTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadAndSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskPayloadSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskSharedMemorySize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupCount": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupInvocations": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxTaskWorkGroupSize": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint32_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 3
-                },
-                "maxTaskWorkGroupTotalCount": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerPrimitiveGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "meshOutputPerVertexGranularity": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "prefersCompactPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersCompactVertexOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationPrimitiveOutput": {
-                    "type": "boolean"
-                },
-                "prefersLocalInvocationVertexOutput": {
-                    "type": "boolean"
                 }
             }
         },
@@ -3533,15 +2211,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxMultiDrawCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
             "type": "object",
             "additionalProperties": false,
@@ -3560,73 +2229,6 @@
                 },
                 "maxMultiviewViewCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxOpacity2StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxOpacity4StateSubdivisionLevel": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkOpticalFlowGridSizeFlagBitsNV": {
-            "enum": [
-                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
-                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
-            ]
-        },
-        "VkOpticalFlowGridSizeFlagsNV": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
-            },
-            "uniqueItems": true
-        },
-        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bidirectionalFlowSupported": {
-                    "type": "boolean"
-                },
-                "costSupported": {
-                    "type": "boolean"
-                },
-                "globalFlowSupported": {
-                    "type": "boolean"
-                },
-                "hintSupported": {
-                    "type": "boolean"
-                },
-                "maxHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxNumRegionsOfInterest": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minHeight": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minWidth": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "supportedHintGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
-                },
-                "supportedOutputGridSizes": {
-                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
                 }
             }
         },
@@ -3657,40 +2259,6 @@
                 }
             }
         },
-        "VkPipelineRobustnessImageBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
-            ]
-        },
-        "VkPipelineRobustnessBufferBehaviorEXT": {
-            "enum": [
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
-                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
-            ]
-        },
-        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "defaultRobustnessImages": {
-                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
-                },
-                "defaultRobustnessStorageBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessUniformBuffers": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                },
-                "defaultRobustnessVertexInputs": {
-                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
-                }
-            }
-        },
         "VkPointClippingBehavior": {
             "enum": [
                 "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
@@ -3708,32 +2276,11 @@
                 }
             }
         },
-        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minVertexInputBindingStrideAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
         "VkPhysicalDeviceProtectedMemoryProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "protectedNoFault": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "provokingVertexModePerPipeline": {
-                    "type": "boolean"
-                },
-                "transformFeedbackPreservesTriangleFanProvokingVertex": {
                     "type": "boolean"
                 }
             }
@@ -3747,26 +2294,29 @@
                 }
             }
         },
-        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "maxRayDispatchInvocationCount": {
+                "maxDescriptorSetAccelerationStructures": {
                     "$ref": "#/definitions/uint32_t"
                 },
-                "maxRayHitAttributeSize": {
-                    "$ref": "#/definitions/uint32_t"
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
                 },
-                "maxRayRecursionDepth": {
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "maxShaderGroupStride": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupBaseAlignment": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "shaderGroupHandleAlignment": {
                     "$ref": "#/definitions/uint32_t"
                 },
                 "shaderGroupHandleCaptureReplaySize": {
@@ -3929,116 +2479,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "shaderModuleIdentifierAlgorithmUUID": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/uint8_t"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                }
-            }
-        },
         "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -4104,7 +2544,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4122,16 +2562,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxSubpassShadingWorkgroupSizeAspectRatio": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4433,147 +2864,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4587,7 +2877,6 @@
                 "VK_FORMAT_FEATURE_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
                 "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
@@ -4613,11 +2902,7 @@
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
                 "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
             ]
         },
         "VkFormatFeatureFlags": {
@@ -4651,110 +2936,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
-                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
-                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkSubpassResolvePerformanceQueryEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "optimal": {
-                    "type": "boolean"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4767,15 +2948,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkSubpassResolvePerformanceQueryEXT": {
-                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4798,12 +2970,9 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
-                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
-                "VK_QUEUE_TRANSFER_BIT",
-                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
-                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+                "VK_QUEUE_TRANSFER_BIT"
             ]
         },
         "VkQueueFlags": {
@@ -4840,99 +3009,6 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
-            "enum": [
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
-                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_NONE",
-                "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
-            ]
-        },
-        "VkPipelineStageFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyCheckpointProperties2NV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
-                }
-            }
-        },
         "VkPipelineStageFlagBits": {
             "enum": [
                 "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
@@ -4948,18 +3024,13 @@
                 "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
                 "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
-                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
-                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
-                "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
-                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4983,69 +3054,6 @@
             "properties": {
                 "checkpointExecutionStageMask": {
                     "$ref": "#/definitions/VkPipelineStageFlags"
-                }
-            }
-        },
-        "VkQueueGlobalPriorityKHR": {
-            "enum": [
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
-            ]
-        },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "priorities": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
-                    },
-                    "uniqueItems": false,
-                    "maxItems": 16
-                },
-                "priorityCount": {
-                    "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "queryResultStatusSupport": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
-            ]
-        },
-        "VkVideoCodecOperationFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkQueueFamilyVideoPropertiesKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "videoCodecOperations": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
                 }
             }
         }
@@ -5108,9 +3116,6 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
-                            "VK_AMD_shader_early_and_late_fragment_tests": {
-                                "type": "integer"
-                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -5132,37 +3137,19 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_4444_formats": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_acquire_drm_display": {
-                                "type": "integer"
-                            },
                             "VK_EXT_acquire_xlib_display": {
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
-                            "VK_EXT_attachment_feedback_loop_layout": {
-                                "type": "integer"
-                            },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
                                 "type": "integer"
                             },
                             "VK_EXT_calibrated_timestamps": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_color_write_enable": {
                                 "type": "integer"
                             },
                             "VK_EXT_conditional_rendering": {
@@ -5183,12 +3170,6 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
-                            "VK_EXT_depth_clamp_zero_one": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
-                                "type": "integer"
-                            },
                             "VK_EXT_depth_clip_enable": {
                                 "type": "integer"
                             },
@@ -5198,19 +3179,7 @@
                             "VK_EXT_descriptor_indexing": {
                                 "type": "integer"
                             },
-                            "VK_EXT_device_address_binding_report": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_fault": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_device_memory_report": {
-                                "type": "integer"
-                            },
                             "VK_EXT_direct_mode_display": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_directfb_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_discard_rectangles": {
@@ -5220,15 +3189,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_display_surface_counter": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state2": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -5243,9 +3203,6 @@
                             "VK_EXT_fragment_density_map": {
                                 "type": "integer"
                             },
-                            "VK_EXT_fragment_density_map2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_fragment_shader_interlock": {
                                 "type": "integer"
                             },
@@ -5253,12 +3210,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_global_priority": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_global_priority_query": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_graphics_pipeline_library": {
                                 "type": "integer"
                             },
                             "VK_EXT_hdr_metadata": {
@@ -5270,22 +3221,7 @@
                             "VK_EXT_host_query_reset": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_2d_view_of_3d": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_compression_control_swapchain": {
-                                "type": "integer"
-                            },
                             "VK_EXT_image_drm_format_modifier": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -5294,13 +3230,7 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
-                            "VK_EXT_legacy_dithering": {
-                                "type": "integer"
-                            },
                             "VK_EXT_line_rasterization": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_load_store_op_none": {
                                 "type": "integer"
                             },
                             "VK_EXT_memory_budget": {
@@ -5309,37 +3239,10 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
-                            "VK_EXT_mesh_shader": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_metal_objects": {
-                                "type": "integer"
-                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
-                            "VK_EXT_multi_draw": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_multisampled_render_to_single_sampled": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_mutable_descriptor_type": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_non_seamless_cube_map": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_opacity_micromap": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pageable_device_local_memory": {
-                                "type": "integer"
-                            },
                             "VK_EXT_pci_bus_info": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_physical_device_drm": {
                                 "type": "integer"
                             },
                             "VK_EXT_pipeline_creation_cache_control": {
@@ -5348,37 +3251,13 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
-                            "VK_EXT_pipeline_properties": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_protected_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_pipeline_robustness": {
-                                "type": "integer"
-                            },
                             "VK_EXT_post_depth_coverage": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitive_topology_list_restart": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
                                 "type": "integer"
                             },
-                            "VK_EXT_provoking_vertex": {
-                                "type": "integer"
-                            },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -5396,19 +3275,7 @@
                             "VK_EXT_separate_stencil_usage": {
                                 "type": "integer"
                             },
-                            "VK_EXT_shader_atomic_float": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_atomic_float2": {
-                                "type": "integer"
-                            },
                             "VK_EXT_shader_demote_to_helper_invocation": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_image_atomic_int64": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_shader_module_identifier": {
                                 "type": "integer"
                             },
                             "VK_EXT_shader_stencil_export": {
@@ -5424,9 +3291,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5456,34 +3320,7 @@
                             "VK_EXT_vertex_attribute_divisor": {
                                 "type": "integer"
                             },
-                            "VK_EXT_vertex_input_dynamic_state": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_decode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h264": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_ycbcr_2plane_444_formats": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_memory": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_external_semaphore": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_imagepipe_surface": {
@@ -5504,16 +3341,7 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_invocation_mask": {
-                                "type": "integer"
-                            },
-                            "VK_HUAWEI_subpass_shading": {
                                 "type": "integer"
                             },
                             "VK_IMG_filter_cubic": {
@@ -5534,9 +3362,6 @@
                             "VK_KHR_8bit_storage": {
                                 "type": "integer"
                             },
-                            "VK_KHR_acceleration_structure": {
-                                "type": "integer"
-                            },
                             "VK_KHR_android_surface": {
                                 "type": "integer"
                             },
@@ -5544,9 +3369,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_buffer_device_address": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_copy_commands2": {
                                 "type": "integer"
                             },
                             "VK_KHR_create_renderpass2": {
@@ -5580,9 +3402,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_driver_properties": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_dynamic_rendering": {
                                 "type": "integer"
                             },
                             "VK_KHR_external_fence": {
@@ -5621,15 +3440,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shader_barycentric": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_fragment_shading_rate": {
-                                "type": "integer"
-                            },
                             "VK_KHR_get_display_properties2": {
                                 "type": "integer"
                             },
@@ -5640,9 +3450,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5663,9 +3470,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5678,28 +3482,10 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_subset": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_id": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_present_wait": {
-                                "type": "integer"
-                            },
                             "VK_KHR_push_descriptor": {
                                 "type": "integer"
                             },
-                            "VK_KHR_ray_query": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_maintenance1": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_ray_tracing_pipeline": {
+                            "VK_KHR_ray_tracing": {
                                 "type": "integer"
                             },
                             "VK_KHR_relaxed_block_layout": {
@@ -5729,19 +3515,10 @@
                             "VK_KHR_shader_float_controls": {
                                 "type": "integer"
                             },
-                            "VK_KHR_shader_integer_dot_product": {
-                                "type": "integer"
-                            },
                             "VK_KHR_shader_non_semantic_info": {
                                 "type": "integer"
                             },
                             "VK_KHR_shader_subgroup_extended_types": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_subgroup_uniform_control_flow": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_shader_terminate_invocation": {
                                 "type": "integer"
                             },
                             "VK_KHR_shared_presentable_image": {
@@ -5765,9 +3542,6 @@
                             "VK_KHR_swapchain_mutable_format": {
                                 "type": "integer"
                             },
-                            "VK_KHR_synchronization2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_timeline_semaphore": {
                                 "type": "integer"
                             },
@@ -5775,15 +3549,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_variable_pointers": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_decode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_encode_queue": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_video_queue": {
                                 "type": "integer"
                             },
                             "VK_KHR_vulkan_memory_model": {
@@ -5798,16 +3563,10 @@
                             "VK_KHR_win32_surface": {
                                 "type": "integer"
                             },
-                            "VK_KHR_workgroup_memory_explicit_layout": {
-                                "type": "integer"
-                            },
                             "VK_KHR_xcb_surface": {
                                 "type": "integer"
                             },
                             "VK_KHR_xlib_surface": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_zero_initialize_workgroup_memory": {
                                 "type": "integer"
                             },
                             "VK_MVK_ios_surface": {
@@ -5819,16 +3578,10 @@
                             "VK_NN_vi_surface": {
                                 "type": "integer"
                             },
-                            "VK_NVX_binary_import": {
-                                "type": "integer"
-                            },
                             "VK_NVX_image_view_handle": {
                                 "type": "integer"
                             },
                             "VK_NVX_multiview_per_view_attributes": {
-                                "type": "integer"
-                            },
-                            "VK_NV_acquire_winrt_display": {
                                 "type": "integer"
                             },
                             "VK_NV_clip_space_w_scaling": {
@@ -5867,9 +3620,6 @@
                             "VK_NV_external_memory_capabilities": {
                                 "type": "integer"
                             },
-                            "VK_NV_external_memory_rdma": {
-                                "type": "integer"
-                            },
                             "VK_NV_external_memory_win32": {
                                 "type": "integer"
                             },
@@ -5882,9 +3632,6 @@
                             "VK_NV_fragment_shader_barycentric": {
                                 "type": "integer"
                             },
-                            "VK_NV_fragment_shading_rate_enums": {
-                                "type": "integer"
-                            },
                             "VK_NV_framebuffer_mixed_samples": {
                                 "type": "integer"
                             },
@@ -5894,25 +3641,10 @@
                             "VK_NV_glsl_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_inherited_viewport_scissor": {
-                                "type": "integer"
-                            },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
-                            "VK_NV_optical_flow": {
-                                "type": "integer"
-                            },
-                            "VK_NV_present_barrier": {
-                                "type": "integer"
-                            },
                             "VK_NV_ray_tracing": {
-                                "type": "integer"
-                            },
-                            "VK_NV_ray_tracing_motion_blur": {
                                 "type": "integer"
                             },
                             "VK_NV_representative_fragment_test": {
@@ -5945,12 +3677,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_image_processing": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5958,24 +3684,6 @@
                                 "type": "integer"
                             },
                             "VK_QCOM_render_pass_transform": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_rotated_copy_commands": {
-                                "type": "integer"
-                            },
-                            "VK_QCOM_tile_properties": {
-                                "type": "integer"
-                            },
-                            "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_SEC_amigo_profiling": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
                         }
@@ -6000,9 +3708,6 @@
                             "VkPhysicalDevice16BitStorageFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
                             },
-                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDevice8BitStorageFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
                             },
@@ -6012,23 +3717,8 @@
                             "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
                             },
-                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
-                            },
-                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
                             },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
@@ -6044,9 +3734,6 @@
                             },
                             "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
-                            },
-                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
                             },
                             "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
@@ -6069,12 +3756,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -6084,101 +3765,29 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFaultFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
-                            },
-                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -6189,47 +3798,17 @@
                             "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
                             },
-                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
-                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
-                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -6237,95 +3816,20 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
-                            },
-                            "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
-                            },
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
-                            },
-                            "VkPhysicalDevicePresentIdFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
-                            },
-                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
-                            },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
-                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
-                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
-                            },
-                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
-                            },
-                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
                             },
                             "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
@@ -6351,12 +3855,6 @@
                             "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
                             },
-                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
-                            },
-                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderAtomicInt64Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
                             },
@@ -6366,20 +3864,14 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
-                            },
-                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
                             },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
@@ -6390,23 +3882,11 @@
                             "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
-                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
-                            },
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -6417,47 +3897,17 @@
                             "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
                             },
-                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
-                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
-                            },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
-                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
-                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -6489,17 +3939,11 @@
                             "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
                             },
-                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
-                            },
                             "VkPhysicalDeviceVulkan11Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
                             },
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
-                            },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
                             },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
@@ -6507,20 +3951,8 @@
                             "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
-                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
-                            },
-                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
-                            },
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
                             }
                         }
                     },
@@ -6537,9 +3969,6 @@
                             },
                             "VkPhysicalDeviceProperties2KHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProperties2"
-                            },
-                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
                             },
                             "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
@@ -6577,12 +4006,6 @@
                             "VkPhysicalDeviceDriverPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
                             },
-                            "VkPhysicalDeviceDrmPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
-                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -6592,26 +4015,8 @@
                             "VkPhysicalDeviceFloatControlsPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
                             },
-                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
-                            },
-                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
-                            },
-                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -6619,14 +4024,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
-                            },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -6637,20 +4036,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
-                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
-                            },
-                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
                             },
                             "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
@@ -6661,20 +4048,11 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
-                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
-                            },
-                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
-                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
-                            },
-                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -6682,20 +4060,14 @@
                             "VkPhysicalDevicePointClippingPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
-                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
-                            },
                             "VkPhysicalDeviceProtectedMemoryProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
-                            },
-                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
                             },
                             "VkPhysicalDevicePushDescriptorPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
                             },
-                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
                             },
                             "VkPhysicalDeviceRayTracingPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
@@ -6718,15 +4090,6 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
-                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
-                            },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
                             },
@@ -6736,20 +4099,11 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
-                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
-                            },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -6768,9 +4122,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6818,18 +4169,6 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6851,9 +4190,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6861,9 +4197,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6875,9 +4208,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6885,9 +4215,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6899,9 +4226,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6909,9 +4233,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6923,9 +4244,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6933,9 +4251,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6947,9 +4262,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6957,9 +4269,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6971,9 +4280,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6981,9 +4287,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6995,9 +4298,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7005,9 +4305,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -7211,12 +4508,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7251,12 +4542,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
@@ -7295,12 +4580,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -7335,12 +4614,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
@@ -7461,9 +4734,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16B16_USCALED": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_R16G16_S10_5_NV": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_R16G16_SFLOAT": {
@@ -7703,23 +4973,8 @@
                                 "VkQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyProperties2"
                                 },
-                                "VkQueueFamilyCheckpointProperties2NV": {
-                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
-                                },
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
-                                },
-                                "VkQueueFamilyVideoPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }

--- a/vulkan/profiles-0.8.1-141.json
+++ b/vulkan/profiles-0.8.1-141.json
@@ -1,0 +1,5114 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-141.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.141",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-142.json
+++ b/vulkan/profiles-0.8.1-142.json
@@ -1,0 +1,5114 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-142.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.142",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-143.json
+++ b/vulkan/profiles-0.8.1-143.json
@@ -1,0 +1,5126 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-143.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.143",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-144.json
+++ b/vulkan/profiles-0.8.1-144.json
@@ -1,0 +1,5126 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-144.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.144",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-145.json
+++ b/vulkan/profiles-0.8.1-145.json
@@ -1,0 +1,5141 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-145.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.145",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-146.json
+++ b/vulkan/profiles-0.8.1-146.json
@@ -1,0 +1,5180 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-146.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.146",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-147.json
+++ b/vulkan/profiles-0.8.1-147.json
@@ -1,0 +1,5180 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-147.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.147",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-148.json
+++ b/vulkan/profiles-0.8.1-148.json
@@ -1,0 +1,5244 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-148.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.148",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-149.json
+++ b/vulkan/profiles-0.8.1-149.json
@@ -1,0 +1,5268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-149.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.149",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-150.json
+++ b/vulkan/profiles-0.8.1-150.json
@@ -1,0 +1,5268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-150.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.150",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-151.json
+++ b/vulkan/profiles-0.8.1-151.json
@@ -1,0 +1,5268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-151.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.151",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-152.json
+++ b/vulkan/profiles-0.8.1-152.json
@@ -1,0 +1,5268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-152.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.152",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-153.json
+++ b/vulkan/profiles-0.8.1-153.json
@@ -1,0 +1,5268 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-153.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.153",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-154.json
+++ b/vulkan/profiles-0.8.1-154.json
@@ -1,0 +1,5340 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-154.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.154",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-155.json
+++ b/vulkan/profiles-0.8.1-155.json
@@ -1,0 +1,5358 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-155.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.155",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-156.json
+++ b/vulkan/profiles-0.8.1-156.json
@@ -1,0 +1,5373 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-156.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.156",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-157.json
+++ b/vulkan/profiles-0.8.1-157.json
@@ -1,0 +1,5373 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-157.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.157",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-158.json
+++ b/vulkan/profiles-0.8.1-158.json
@@ -1,0 +1,5471 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-158.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.158",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-159.json
+++ b/vulkan/profiles-0.8.1-159.json
@@ -1,0 +1,5474 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-159.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.159",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-160.json
+++ b/vulkan/profiles-0.8.1-160.json
@@ -1,0 +1,5507 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-160.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.160",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-161.json
+++ b/vulkan/profiles-0.8.1-161.json
@@ -1,0 +1,5507 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-161.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.161",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                },
+                "rayTracing": {
+                    "type": "boolean"
+                },
+                "rayTracingAccelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingHostAccelerationStructureCommands": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectAccelerationStructureBuild": {
+                    "type": "boolean"
+                },
+                "rayTracingIndirectTraceRays": {
+                    "type": "boolean"
+                },
+                "rayTracingPrimitiveCulling": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayTracingFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-162.json
+++ b/vulkan/profiles-0.8.1-162.json
@@ -1,0 +1,5567 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-162.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.162",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-163.json
+++ b/vulkan/profiles-0.8.1-163.json
@@ -1,0 +1,5567 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-163.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.163",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-164.json
+++ b/vulkan/profiles-0.8.1-164.json
@@ -1,0 +1,5585 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-164.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.164",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-165.json
+++ b/vulkan/profiles-0.8.1-165.json
@@ -1,0 +1,5585 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-165.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.165",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-166.json
+++ b/vulkan/profiles-0.8.1-166.json
@@ -1,0 +1,5585 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-166.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.166",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-167.json
+++ b/vulkan/profiles-0.8.1-167.json
@@ -1,0 +1,5585 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-167.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.167",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-168.json
+++ b/vulkan/profiles-0.8.1-168.json
@@ -1,0 +1,5624 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-168.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.168",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-169.json
+++ b/vulkan/profiles-0.8.1-169.json
@@ -1,0 +1,5624 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-169.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.169",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-170.json
+++ b/vulkan/profiles-0.8.1-170.json
@@ -1,0 +1,5701 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-170.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.170",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-171.json
+++ b/vulkan/profiles-0.8.1-171.json
@@ -1,0 +1,5704 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-171.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.171",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-172.json
+++ b/vulkan/profiles-0.8.1-172.json
@@ -1,0 +1,5704 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-172.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.172",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-173.json
+++ b/vulkan/profiles-0.8.1-173.json
@@ -1,0 +1,5710 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-173.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.173",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-174.json
+++ b/vulkan/profiles-0.8.1-174.json
@@ -1,0 +1,5710 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-174.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.174",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-175.json
+++ b/vulkan/profiles-0.8.1-175.json
@@ -1,0 +1,5888 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-175.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.175",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-176.json
+++ b/vulkan/profiles-0.8.1-176.json
@@ -1,0 +1,5909 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-176.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.176",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-177.json
+++ b/vulkan/profiles-0.8.1-177.json
@@ -1,0 +1,5942 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-177.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.177",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-178.json
+++ b/vulkan/profiles-0.8.1-178.json
@@ -1,0 +1,5946 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-178.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.178",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-179.json
+++ b/vulkan/profiles-0.8.1-179.json
@@ -1,0 +1,5946 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-179.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.179",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-180.json
+++ b/vulkan/profiles-0.8.1-180.json
@@ -1,0 +1,6004 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-180.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.180",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-181.json
+++ b/vulkan/profiles-0.8.1-181.json
@@ -1,0 +1,6004 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-181.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.181",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-182.json
+++ b/vulkan/profiles-0.8.1-182.json
@@ -1,0 +1,6111 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-182.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.182",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-183.json
+++ b/vulkan/profiles-0.8.1-183.json
@@ -1,0 +1,6111 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-183.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.183",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-184.json
+++ b/vulkan/profiles-0.8.1-184.json
@@ -1,0 +1,6126 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-184.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.184",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-185.json
+++ b/vulkan/profiles-0.8.1-185.json
@@ -1,0 +1,6220 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-185.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.185",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-186.json
+++ b/vulkan/profiles-0.8.1-186.json
@@ -1,0 +1,6220 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-186.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.186",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-187.json
+++ b/vulkan/profiles-0.8.1-187.json
@@ -1,0 +1,6220 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-187.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.187",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-188.json
+++ b/vulkan/profiles-0.8.1-188.json
@@ -1,0 +1,6224 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-188.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.188",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_load_store_op_none": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-189.json
+++ b/vulkan/profiles-0.8.1-189.json
@@ -1,0 +1,6224 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-189.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.189",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_load_store_op_none": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-190.json
+++ b/vulkan/profiles-0.8.1-190.json
@@ -1,0 +1,6356 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-190.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.190",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice4444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatA4B4G4R4": {
+                    "type": "boolean"
+                },
+                "formatA4R4G4B4": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "accelerationStructure": {
+                    "type": "boolean"
+                },
+                "accelerationStructureCaptureReplay": {
+                    "type": "boolean"
+                },
+                "accelerationStructureHostCommands": {
+                    "type": "boolean"
+                },
+                "accelerationStructureIndirectBuild": {
+                    "type": "boolean"
+                },
+                "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceCoherentMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "colorWriteEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrix": {
+                    "type": "boolean"
+                },
+                "cooperativeMatrixRobustBufferAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coverageReductionMode": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "customBorderColorWithoutFormat": {
+                    "type": "boolean"
+                },
+                "customBorderColors": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClipEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceGeneratedCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceMemoryReport": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "diagnosticsConfig": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState2": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2LogicOp": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState2PatchControlPoints": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMapDeferred": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderPixelInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderSampleInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShaderShadingRateInterlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateEnums": {
+                    "type": "boolean"
+                },
+                "noInvocationFragmentShadingRates": {
+                    "type": "boolean"
+                },
+                "supersampleFragmentShadingRates": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "pipelineFragmentShadingRate": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRate": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "globalPriorityQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceHostQueryResetFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustImageAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImagelessFramebufferFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "indexTypeUint8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "inheritedViewportScissor2D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "invocationMask": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bresenhamLines": {
+                    "type": "boolean"
+                },
+                "rectangularLines": {
+                    "type": "boolean"
+                },
+                "smoothLines": {
+                    "type": "boolean"
+                },
+                "stippledBresenhamLines": {
+                    "type": "boolean"
+                },
+                "stippledRectangularLines": {
+                    "type": "boolean"
+                },
+                "stippledSmoothLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "performanceCounterMultipleQueryPools": {
+                    "type": "boolean"
+                },
+                "performanceCounterQueryPools": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineCreationCacheControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "constantAlphaColorBlendFactors": {
+                    "type": "boolean"
+                },
+                "events": {
+                    "type": "boolean"
+                },
+                "imageView2DOn3DImage": {
+                    "type": "boolean"
+                },
+                "imageViewFormatReinterpretation": {
+                    "type": "boolean"
+                },
+                "imageViewFormatSwizzle": {
+                    "type": "boolean"
+                },
+                "multisampleArrayImage": {
+                    "type": "boolean"
+                },
+                "mutableComparisonSamplers": {
+                    "type": "boolean"
+                },
+                "pointPolygons": {
+                    "type": "boolean"
+                },
+                "samplerMipLodBias": {
+                    "type": "boolean"
+                },
+                "separateStencilMaskRef": {
+                    "type": "boolean"
+                },
+                "shaderSampleRateInterpolationFunctions": {
+                    "type": "boolean"
+                },
+                "tessellationIsolines": {
+                    "type": "boolean"
+                },
+                "tessellationPointMode": {
+                    "type": "boolean"
+                },
+                "triangleFans": {
+                    "type": "boolean"
+                },
+                "vertexAttributeAccessBeyondStride": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentIdFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentId": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePresentWaitFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentWait": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitiveTopologyListRestart": {
+                    "type": "boolean"
+                },
+                "primitiveTopologyPatchListRestart": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "privateData": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexLast": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayQueryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMotionBlur": {
+                    "type": "boolean"
+                },
+                "rayTracingMotionBlurPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingPipeline": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplay": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect": {
+                    "type": "boolean"
+                },
+                "rayTraversalPrimitiveCulling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nullDescriptor": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess2": {
+                    "type": "boolean"
+                },
+                "robustImageAccess2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat16Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicMinMax": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicMinMax": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderBufferFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderImageFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat32Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64AtomicAdd": {
+                    "type": "boolean"
+                },
+                "shaderSharedFloat64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32AtomicAdd": {
+                    "type": "boolean"
+                },
+                "sparseImageFloat32Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderClockFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDeviceClock": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupClock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDemoteToHelperInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParametersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderFloat16Int8Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderImageInt64Atomics": {
+                    "type": "boolean"
+                },
+                "sparseImageInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerDotProduct": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMBuiltins": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSubgroupUniformControlFlow": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderTerminateInvocation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeFullSubgroups": {
+                    "type": "boolean"
+                },
+                "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassShading": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "synchronization2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "texelBufferAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "timelineSemaphore": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointersFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexInputDynamicState": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                },
+                "protectedMemory": {
+                    "type": "boolean"
+                },
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                },
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                },
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Features": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                },
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "descriptorIndexing": {
+                    "type": "boolean"
+                },
+                "drawIndirectCount": {
+                    "type": "boolean"
+                },
+                "hostQueryReset": {
+                    "type": "boolean"
+                },
+                "imagelessFramebuffer": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "samplerFilterMinmax": {
+                    "type": "boolean"
+                },
+                "samplerMirrorClampToEdge": {
+                    "type": "boolean"
+                },
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                },
+                "separateDepthStencilLayouts": {
+                    "type": "boolean"
+                },
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                },
+                "shaderOutputLayer": {
+                    "type": "boolean"
+                },
+                "shaderOutputViewportIndex": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSubgroupExtendedTypes": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "subgroupBroadcastDynamicId": {
+                    "type": "boolean"
+                },
+                "timelineSemaphore": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "uniformBufferStandardLayout": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelAvailabilityVisibilityChains": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workgroupMemoryExplicitLayout": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout16BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayout8BitAccess": {
+                    "type": "boolean"
+                },
+                "workgroupMemoryExplicitLayoutScalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcr2plane444Formats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ycbcrImageArrays": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderZeroInitializeWorkgroupMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxPerStageDescriptorAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPrimitiveCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "minAccelerationStructureScratchOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_KHR",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cooperativeMatrixSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxCustomBorderColorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkResolveModeFlagBits": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT",
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolveProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxGraphicsShaderGroupCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsStreamStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectCommandsTokenOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxIndirectSequenceCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minIndirectCommandsBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesCountBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSequencesIndexBufferOffsetAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverId": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE",
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY",
+                "VK_DRIVER_ID_BROADCOM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_COREAVI_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY",
+                "VK_DRIVER_ID_GGP_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER",
+                "VK_DRIVER_ID_GOOGLE_SWIFTSHADER_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_LLVMPIPE",
+                "VK_DRIVER_ID_MESA_RADV",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_MOLTENVK",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
+            ]
+        },
+        "VkPhysicalDeviceDriverProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceDrmPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "hasPrimary": {
+                    "type": "boolean"
+                },
+                "hasRender": {
+                    "type": "boolean"
+                },
+                "primaryMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "primaryMinor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMajor": {
+                    "$ref": "#/definitions/int64_t"
+                },
+                "renderMinor": {
+                    "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkShaderFloatControlsIndependence": {
+            "enum": [
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_32_BIT_ONLY_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL_KHR",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE",
+                "VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"
+            ]
+        },
+        "VkPhysicalDeviceFloatControlsProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetSubsampledSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubsampledArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subsampledCoarseReconstructionEarlyAccess": {
+                    "type": "boolean"
+                },
+                "subsampledLoads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxFragmentShadingRateInvocationCount": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShadingRateNonTrivialCombinerOps": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateStrictMultiplyCombiner": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithConservativeRasterization": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithCustomSampleLocations": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithFragmentShaderInterlock": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithSampleMask": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderDepthStencilWrites": {
+                    "type": "boolean"
+                },
+                "fragmentShadingRateWithShaderSampleMask": {
+                    "type": "boolean"
+                },
+                "layeredShadingRateAttachments": {
+                    "type": "boolean"
+                },
+                "maxFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateCoverageSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentShadingRateRasterizationSamples": {
+                    "$ref": "#/definitions/VkSampleCountFlagBits"
+                },
+                "maxFragmentSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxFragmentSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minFragmentShadingRateAttachmentTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "lineSubPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiDrawCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowCommandBufferQueryCopies": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minVertexInputBindingStrideAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provokingVertexModePerPipeline": {
+                    "type": "boolean"
+                },
+                "transformFeedbackPreservesTriangleFanProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxRayDispatchInvocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayHitAttributeSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxRayRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleCaptureReplaySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRobustness2PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "robustStorageBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "robustUniformBufferAccessSizeAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkShaderCorePropertiesFlagBitsAMD": {
+            "enum": [
+                0
+            ]
+        },
+        "VkShaderCorePropertiesFlagsAMD": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderCorePropertiesFlagBitsAMD"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceShaderCoreProperties2AMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "activeComputeUnitCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderCoreFeatures": {
+                    "$ref": "#/definitions/VkShaderCorePropertiesFlagsAMD"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "integerDotProduct16BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct16BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct16BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct32BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct32BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct32BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct4x8BitPackedSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct64BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct64BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct64BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct8BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct8BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProduct8BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
+                    "type": "boolean"
+                },
+                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderSMCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderWarpsPerSM": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxComputeWorkgroupSubgroups": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSubgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "requiredSubgroupSizeStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSubpassShadingWorkgroupSizeAspectRatio": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "storageTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                },
+                "uniformTexelBufferOffsetAlignmentBytes": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "uniformTexelBufferOffsetSingleTexelAlignment": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTimelineSemaphoreProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan11Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                },
+                "protectedNoFault": {
+                    "type": "boolean"
+                },
+                "subgroupQuadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subgroupSupportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "subgroupSupportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkan12Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersion"
+                },
+                "denormBehaviorIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverId"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                },
+                "framebufferIntegerColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTimelineSemaphoreValueDifference": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "roundingModeIndependence": {
+                    "$ref": "#/definitions/VkShaderFloatControlsIndependence"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlags"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR",
+                "VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "VkVideoComponentBitDepthFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
+                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
+            ]
+        },
+        "VkVideoComponentBitDepthFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoChromaSubsamplingFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
+                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
+            ]
+        },
+        "VkVideoChromaSubsamplingFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
+        },
+        "VkVideoProfileKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "chromaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "chromaSubsampling": {
+                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
+                },
+                "lumaBitDepth": {
+                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
+                },
+                "videoCodecOperation": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkVideoProfileKHR": {
+                    "$ref": "#/definitions/VkVideoProfileKHR"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT",
+                "VK_QUEUE_VIDEO_DECODE_BIT_KHR",
+                "VK_QUEUE_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits2KHR": {
+            "enum": [
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
+            ]
+        },
+        "VkPipelineStageFlags2KHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointProperties2NV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_NONE_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        },
+        "VkQueueGlobalPriorityEXT": {
+            "enum": [
+                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
+            ]
+        },
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "priorities": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "priorityCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkVideoCodecOperationFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkVideoQueueFamilyProperties2KHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "videoCodecOperations": {
+                    "$ref": "#/definitions/VkVideoCodecOperationFlagsKHR"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_device_coherent_memory": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_display_native_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_pipeline_compiler_control": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_4444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_drm_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_color_write_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_custom_border_color": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clip_enable": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_memory_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_directfb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_shader_interlock": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_full_screen_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority_query": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_headless_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_robustness": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_index_type_uint8": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_line_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_load_store_op_none": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_surface": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_physical_device_drm": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_cache_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_creation_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_private_data": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_provoking_vertex": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_robustness2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_atomic_float2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_demote_to_helper_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_image_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texel_buffer_alignment": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_texture_compression_astc_hdr": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_tooling_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_input_dynamic_state": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_decode_h265": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_video_encode_h264": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_2plane_444_formats": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_ycbcr_image_arrays": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_frame_token": {
+                                "type": "integer"
+                            },
+                            "VK_GGP_stream_descriptor_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_user_type": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_invocation_mask": {
+                                "type": "integer"
+                            },
+                            "VK_HUAWEI_subpass_shading": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_INTEL_shader_integer_functions2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_acceleration_structure": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_copy_commands2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_deferred_host_operations": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_fragment_shading_rate": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_imageless_framebuffer": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_performance_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_executable_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_pipeline_library": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_portability_subset": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_id": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_present_wait": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_pipeline": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_separate_depth_stencil_layouts": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_clock": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_integer_dot_product": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_non_semantic_info": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_extended_types": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_subgroup_uniform_control_flow": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_terminate_invocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_spirv_1_4": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface_protected_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_synchronization2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_timeline_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_uniform_buffer_standard_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_decode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_encode_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_video_queue": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_workgroup_memory_explicit_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_zero_initialize_workgroup_memory": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_binary_import": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_image_view_handle": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_acquire_winrt_display": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_cooperative_matrix": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_coverage_reduction_mode": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation_image_aliasing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostics_config": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_rdma": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shading_rate_enums": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_inherited_viewport_scissor": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing_motion_blur": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_sm_builtins": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_shader_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_store_ops": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_render_pass_transform": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_VALVE_mutable_descriptor_type": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice4444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevice4444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDevice8BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeatures"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
+                            },
+                            "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCoherentMemoryFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoherentMemoryFeaturesAMD"
+                            },
+                            "VkPhysicalDeviceColorWriteEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceColorWriteEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCoverageReductionModeFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCoverageReductionModeFeaturesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceMemoryReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceImagelessFramebufferFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
+                            },
+                            "VkPhysicalDeviceIndexTypeUint8FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIndexTypeUint8FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentIdFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentWaitFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentWaitFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrivateDataFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelineFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64Features"
+                            },
+                            "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
+                            },
+                            "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures"
+                            },
+                            "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
+                            },
+                            "VkPhysicalDeviceSynchronization2FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceUniformBufferStandardLayoutFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointersFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointersFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Features"
+                            },
+                            "VkPhysicalDeviceVulkan12Features": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
+                            },
+                            "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructurePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCooperativeMatrixPropertiesNV"
+                            },
+                            "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCustomBorderColorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolveProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolveProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingProperties"
+                            },
+                            "VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverProperties"
+                            },
+                            "VkPhysicalDeviceDrmPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsProperties"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiDrawPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiDrawPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePortabilitySubsetPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPipelinePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceRobustness2PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRobustness2PropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxProperties"
+                            },
+                            "VkPhysicalDeviceShaderCoreProperties2AMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCoreProperties2AMD"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
+                            },
+                            "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphoreProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTimelineSemaphorePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVulkan11Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan11Properties"
+                            },
+                            "VkPhysicalDeviceVulkan12Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointProperties2NV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointProperties2NV"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                },
+                                "VkQueueFamilyGlobalPriorityPropertiesEXT": {
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
+                                },
+                                "VkVideoQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-191.json
+++ b/vulkan/profiles-0.8.1-191.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-191.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.191",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -352,18 +352,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBufferDeviceAddressFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -487,15 +475,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +550,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +573,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +697,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +715,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +751,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -849,24 +792,6 @@
                     "type": "boolean"
                 },
                 "stippledSmoothLines": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
                     "type": "boolean"
                 }
             }
@@ -946,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +970,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1071,30 +996,6 @@
                     "type": "boolean"
                 },
                 "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1201,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1252,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1318,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1339,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1669,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2614,18 +2464,13 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2624,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2741,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2944,15 +2780,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3306,7 +3133,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3294,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3321,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3623,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,132 +3700,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
                 "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
@@ -4176,7 +3736,6 @@
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
             ]
         },
@@ -4210,24 +3769,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3835,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3893,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +3917,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +3947,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4068,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4583,9 +4081,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -4613,9 +4108,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4693,9 +4185,6 @@
                             "VK_EXT_image_robustness": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_view_min_lod": {
-                                "type": "integer"
-                            },
                             "VK_EXT_index_type_uint8": {
                                 "type": "integer"
                             },
@@ -4748,9 +4237,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -4834,16 +4320,10 @@
                             "VK_EXT_video_encode_h264": {
                                 "type": "integer"
                             },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_2plane_444_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_external_memory": {
@@ -4868,9 +4348,6 @@
                                 "type": "integer"
                             },
                             "VK_GOOGLE_hlsl_functionality1": {
-                                "type": "integer"
-                            },
-                            "VK_GOOGLE_surfaceless_query": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_user_type": {
@@ -4948,9 +4425,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -4987,9 +4461,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5003,9 +4474,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5026,9 +4494,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5039,9 +4504,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4719,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4758,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4771,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5363,9 +4816,6 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
                             },
@@ -5405,9 +4855,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4864,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4872,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +4891,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +4903,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +4912,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,26 +4927,14 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +4960,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,23 +4978,14 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
                             "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5035,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5059,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5077,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5137,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5152,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5225,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5240,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5879,12 +5251,6 @@
                             },
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5315,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5327,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5353,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5400,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5427,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5434,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5445,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5452,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5463,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5470,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5481,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5488,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5499,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5506,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5517,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5524,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5535,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5542,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5745,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5782,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5823,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5860,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6228,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6317,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-192.json
+++ b/vulkan/profiles-0.8.1-192.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-192.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.192",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -352,18 +352,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBufferDeviceAddressFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -487,15 +475,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +550,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +573,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +697,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +715,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +751,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -849,24 +792,6 @@
                     "type": "boolean"
                 },
                 "stippledSmoothLines": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
                     "type": "boolean"
                 }
             }
@@ -946,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +970,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1071,30 +996,6 @@
                     "type": "boolean"
                 },
                 "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1201,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1252,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1318,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1339,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1669,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2614,18 +2464,13 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
-                "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
                 "VK_DRIVER_ID_MESA_RADV_KHR",
-                "VK_DRIVER_ID_MESA_TURNIP",
-                "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2624,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2741,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2944,15 +2780,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3306,7 +3133,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3294,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3321,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3623,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,132 +3700,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
                 "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
@@ -4176,7 +3736,6 @@
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
             ]
         },
@@ -4210,24 +3769,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3835,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3893,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +3917,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +3947,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4068,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4583,9 +4081,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -4613,9 +4108,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4693,9 +4185,6 @@
                             "VK_EXT_image_robustness": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_view_min_lod": {
-                                "type": "integer"
-                            },
                             "VK_EXT_index_type_uint8": {
                                 "type": "integer"
                             },
@@ -4748,9 +4237,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -4834,16 +4320,10 @@
                             "VK_EXT_video_encode_h264": {
                                 "type": "integer"
                             },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_2plane_444_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_external_memory": {
@@ -4868,9 +4348,6 @@
                                 "type": "integer"
                             },
                             "VK_GOOGLE_hlsl_functionality1": {
-                                "type": "integer"
-                            },
-                            "VK_GOOGLE_surfaceless_query": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_user_type": {
@@ -4948,9 +4425,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -4987,9 +4461,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5003,9 +4474,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5026,9 +4494,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5039,9 +4504,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4719,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4758,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4771,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5363,9 +4816,6 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
                             },
@@ -5405,9 +4855,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4864,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4872,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +4891,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +4903,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +4912,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,26 +4927,14 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +4960,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,23 +4978,14 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
                             "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5035,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5059,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5077,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5137,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5152,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5225,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5240,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5879,12 +5251,6 @@
                             },
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5315,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5327,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5353,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5400,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5427,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5434,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5445,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5452,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5463,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5470,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5481,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5488,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5499,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5506,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5517,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5524,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5535,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5542,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5745,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5782,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5823,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5860,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6228,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6317,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-193.json
+++ b/vulkan/profiles-0.8.1-193.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-193.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.193",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -352,18 +352,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBufferDeviceAddressFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -487,15 +475,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +550,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +573,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +697,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +715,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +751,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -849,24 +792,6 @@
                     "type": "boolean"
                 },
                 "stippledSmoothLines": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
                     "type": "boolean"
                 }
             }
@@ -946,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +970,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1071,30 +996,6 @@
                     "type": "boolean"
                 },
                 "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1201,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1252,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1318,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1339,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1669,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2469,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2627,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2744,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2944,15 +2783,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3306,7 +3136,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3324,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3626,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,132 +3703,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
                 "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
@@ -4176,7 +3739,6 @@
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
             ]
         },
@@ -4210,24 +3772,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3838,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3896,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +3920,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +3950,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4071,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4583,9 +4084,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -4613,9 +4111,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4693,9 +4188,6 @@
                             "VK_EXT_image_robustness": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_view_min_lod": {
-                                "type": "integer"
-                            },
                             "VK_EXT_index_type_uint8": {
                                 "type": "integer"
                             },
@@ -4748,9 +4240,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -4834,16 +4323,10 @@
                             "VK_EXT_video_encode_h264": {
                                 "type": "integer"
                             },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_2plane_444_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_ycbcr_image_arrays": {
-                                "type": "integer"
-                            },
-                            "VK_FUCHSIA_buffer_collection": {
                                 "type": "integer"
                             },
                             "VK_FUCHSIA_external_memory": {
@@ -4868,9 +4351,6 @@
                                 "type": "integer"
                             },
                             "VK_GOOGLE_hlsl_functionality1": {
-                                "type": "integer"
-                            },
-                            "VK_GOOGLE_surfaceless_query": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_user_type": {
@@ -4948,9 +4428,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -4987,9 +4464,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5003,9 +4477,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5026,9 +4497,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5039,9 +4507,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4722,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4761,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4774,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5363,9 +4819,6 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
                             },
@@ -5405,9 +4858,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4867,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4875,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +4894,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +4906,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +4915,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,26 +4930,14 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +4963,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,23 +4981,14 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
                             "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5038,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5062,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5080,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5140,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5155,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5228,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5243,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5879,12 +5254,6 @@
                             },
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5318,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5330,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5356,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5403,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5430,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5437,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5448,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5455,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5466,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5473,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5484,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5491,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5502,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5509,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5520,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5527,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5538,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5545,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5748,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5785,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5826,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5863,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6231,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6320,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-194.json
+++ b/vulkan/profiles-0.8.1-194.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-194.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.194",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -352,18 +352,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBufferDeviceAddressFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -487,15 +475,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +550,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +573,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +697,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +715,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +751,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -849,24 +792,6 @@
                     "type": "boolean"
                 },
                 "stippledSmoothLines": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maintenance4": {
                     "type": "boolean"
                 }
             }
@@ -946,7 +871,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +970,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1071,30 +996,6 @@
                     "type": "boolean"
                 },
                 "transformFeedbackPreservesProvokingVertex": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1201,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1252,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1318,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1339,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1618,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1669,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2469,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2627,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2744,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2944,15 +2783,6 @@
                 },
                 "maxPerSetDescriptors": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
                 }
             }
         },
@@ -3306,7 +3136,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3297,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3324,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3626,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,132 +3703,6 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
-            "enum": [
-                "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
-            ]
-        },
-        "VkFormatFeatureFlags2": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
-            },
-            "uniqueItems": true
-        },
-        "VkFormatProperties3": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                },
-                "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
-                }
-            }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
                 "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
@@ -4176,7 +3739,6 @@
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
             ]
         },
@@ -4210,24 +3772,6 @@
                 },
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
-                },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3838,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3896,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +3920,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +3950,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4071,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4583,9 +4084,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -4613,9 +4111,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4693,9 +4188,6 @@
                             "VK_EXT_image_robustness": {
                                 "type": "integer"
                             },
-                            "VK_EXT_image_view_min_lod": {
-                                "type": "integer"
-                            },
                             "VK_EXT_index_type_uint8": {
                                 "type": "integer"
                             },
@@ -4748,9 +4240,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_rgba10x6_formats": {
                                 "type": "integer"
                             },
                             "VK_EXT_robustness2": {
@@ -4834,9 +4323,6 @@
                             "VK_EXT_video_encode_h264": {
                                 "type": "integer"
                             },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_2plane_444_formats": {
                                 "type": "integer"
                             },
@@ -4868,9 +4354,6 @@
                                 "type": "integer"
                             },
                             "VK_GOOGLE_hlsl_functionality1": {
-                                "type": "integer"
-                            },
-                            "VK_GOOGLE_surfaceless_query": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_user_type": {
@@ -4948,9 +4431,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -4987,9 +4467,6 @@
                             "VK_KHR_external_semaphore_win32": {
                                 "type": "integer"
                             },
-                            "VK_KHR_format_feature_flags2": {
-                                "type": "integer"
-                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5003,9 +4480,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_get_surface_capabilities2": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_global_priority": {
                                 "type": "integer"
                             },
                             "VK_KHR_image_format_list": {
@@ -5026,9 +4500,6 @@
                             "VK_KHR_maintenance3": {
                                 "type": "integer"
                             },
-                            "VK_KHR_maintenance4": {
-                                "type": "integer"
-                            },
                             "VK_KHR_multiview": {
                                 "type": "integer"
                             },
@@ -5039,9 +4510,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4725,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4764,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4777,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5363,9 +4822,6 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
                             },
@@ -5405,9 +4861,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4870,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4878,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +4897,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +4909,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +4918,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,26 +4933,14 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
-                            "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +4966,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,23 +4984,14 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
                             },
                             "VkPhysicalDeviceProvokingVertexFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProvokingVertexFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5041,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5065,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5083,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5143,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5158,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5231,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5246,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5879,12 +5257,6 @@
                             },
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
-                            "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5321,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5333,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5359,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5406,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5433,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5440,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5451,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5458,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5469,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5476,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5487,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5494,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5505,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5512,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5523,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5530,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5541,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5548,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5751,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5788,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5829,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5866,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6234,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6323,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-195.json
+++ b/vulkan/profiles-0.8.1-195.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-195.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.195",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -352,18 +352,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "borderColorSwizzle": {
-                    "type": "boolean"
-                },
-                "borderColorSwizzleFromImage": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceBufferDeviceAddressFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -487,15 +475,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +550,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +573,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +643,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +697,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +715,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +751,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +796,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +880,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +979,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1014,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1219,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1270,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1315,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1336,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1375,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1636,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1687,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2487,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2645,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2762,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2804,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3163,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3324,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3351,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3653,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3730,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,65 +3768,27 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
         },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
@@ -4176,7 +3826,6 @@
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
                 "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
             ]
         },
@@ -4211,23 +3860,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3928,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3986,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4010,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4040,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4161,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4583,9 +4174,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_border_color_swizzle": {
                                 "type": "integer"
                             },
                             "VK_EXT_buffer_device_address": {
@@ -4613,9 +4201,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4691,9 +4276,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -4834,9 +4416,6 @@
                             "VK_EXT_video_encode_h264": {
                                 "type": "integer"
                             },
-                            "VK_EXT_video_encode_h265": {
-                                "type": "integer"
-                            },
                             "VK_EXT_ycbcr_2plane_444_formats": {
                                 "type": "integer"
                             },
@@ -4868,9 +4447,6 @@
                                 "type": "integer"
                             },
                             "VK_GOOGLE_hlsl_functionality1": {
-                                "type": "integer"
-                            },
-                            "VK_GOOGLE_surfaceless_query": {
                                 "type": "integer"
                             },
                             "VK_GOOGLE_user_type": {
@@ -4948,9 +4524,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -5005,9 +4578,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4609,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4824,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4863,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4876,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5363,9 +4921,6 @@
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
-                            "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceBorderColorSwizzleFeaturesEXT"
-                            },
                             "VkPhysicalDeviceBufferDeviceAddressFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBufferDeviceAddressFeatures"
                             },
@@ -5405,9 +4960,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4969,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4977,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +4996,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5008,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +5017,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,11 +5032,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5041,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5068,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5086,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5097,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5146,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5170,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5188,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5248,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5263,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5336,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5351,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5363,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5429,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5441,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5467,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5514,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5541,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5548,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5559,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5566,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5577,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5584,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5595,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5602,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5613,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5620,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5631,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5638,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5649,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5656,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5859,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5896,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5937,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5974,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6342,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6431,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-196.json
+++ b/vulkan/profiles-0.8.1-196.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-196.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.196",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -487,15 +487,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +562,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -603,15 +585,6 @@
             "additionalProperties": false,
             "properties": {
                 "diagnosticsConfig": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "dynamicRendering": {
                     "type": "boolean"
                 }
             }
@@ -682,15 +655,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +709,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +727,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +763,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +808,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +892,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +991,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1026,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1231,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1282,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1327,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1348,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1369,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1387,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1648,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1699,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2499,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2657,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2774,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2816,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3175,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3336,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3363,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3665,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3742,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,65 +3780,27 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
-        },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
         },
         "VkVideoComponentBitDepthFlagBitsKHR": {
             "enum": [
@@ -4211,23 +3873,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoProfileKHR": {
                     "$ref": "#/definitions/VkVideoProfileKHR"
@@ -4294,82 +3941,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +3999,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4023,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4053,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4174,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4613,9 +4217,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4691,9 +4292,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -4870,9 +4468,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -4948,9 +4543,6 @@
                             "VK_KHR_driver_properties": {
                                 "type": "integer"
                             },
-                            "VK_KHR_dynamic_rendering": {
-                                "type": "integer"
-                            },
                             "VK_KHR_external_fence": {
                                 "type": "integer"
                             },
@@ -5005,9 +4597,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4628,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4843,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4882,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4895,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5405,9 +4982,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5417,9 +4991,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5428,12 +4999,6 @@
                             },
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
-                            "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5018,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5030,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +5039,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,11 +5054,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5063,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5090,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5108,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5119,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5168,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5192,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5210,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5270,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5285,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5358,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5373,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5385,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5451,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5463,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5489,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5536,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5563,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5570,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5581,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5588,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5599,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5606,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5617,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5624,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5635,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5642,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5653,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5660,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5671,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5678,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5881,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5918,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +5959,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +5996,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6364,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6453,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-197.json
+++ b/vulkan/profiles-0.8.1-197.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-197.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.197",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -487,15 +487,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +562,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +718,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +736,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +772,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +817,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +901,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1000,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1035,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1240,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1291,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1336,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1378,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1396,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1657,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1708,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2508,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2666,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2783,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2825,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3184,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3345,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3372,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3674,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3751,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3789,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3920,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4000,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4058,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4082,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4112,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4233,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4613,9 +4276,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4691,9 +4351,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -4870,9 +4527,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4659,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4690,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4905,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4944,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4957,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5405,9 +5044,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5416,9 +5052,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -5429,11 +5062,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5083,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5095,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +5104,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,11 +5119,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5128,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5155,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5173,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5184,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5233,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5257,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5275,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5335,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5350,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5423,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5438,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5450,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5516,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5528,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5554,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5601,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5628,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5635,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5646,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5653,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5664,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5671,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5682,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5689,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5700,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5707,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5718,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5725,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5736,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5743,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5946,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5983,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6024,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6061,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6429,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6518,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-198.json
+++ b/vulkan/profiles-0.8.1-198.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-198.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.198",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -487,15 +487,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +562,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +718,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,20 +736,11 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "robustImageAccess": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "minLod": {
                     "type": "boolean"
                 }
             }
@@ -808,7 +772,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +817,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +901,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1000,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1035,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1240,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1291,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1336,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1357,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1378,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1396,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1657,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1708,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,13 +2508,11 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY",
                 "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR",
-                "VK_DRIVER_ID_SAMSUNG_PROPRIETARY",
                 "VK_DRIVER_ID_VERISILICON_PROPRIETARY"
             ]
         },
@@ -2779,15 +2666,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2783,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2825,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3184,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3345,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3372,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3674,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3751,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3789,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3920,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4000,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4058,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4082,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4112,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4233,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4613,9 +4276,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4691,9 +4351,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_image_robustness": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_image_view_min_lod": {
                                 "type": "integer"
                             },
                             "VK_EXT_index_type_uint8": {
@@ -4870,9 +4527,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4659,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4690,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4905,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4944,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4957,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5405,9 +5044,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5416,9 +5052,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -5429,11 +5062,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5083,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5095,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,14 +5104,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
-                            "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImagelessFramebufferFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImagelessFramebufferFeatures"
@@ -5501,11 +5119,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5128,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5155,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5173,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5184,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5233,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5257,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5275,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5335,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5350,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5423,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5438,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5450,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5516,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5528,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5554,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5601,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5628,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5635,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5646,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5653,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5664,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5671,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5682,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5689,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5700,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5707,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5718,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5725,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5736,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5743,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5946,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5983,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6024,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6061,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6429,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6518,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-199.json
+++ b/vulkan/profiles-0.8.1-199.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-199.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.199",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -487,15 +487,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "depthClipControl": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -571,15 +562,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +589,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +664,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +718,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,7 +736,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -808,7 +781,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +826,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +910,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1009,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1044,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1249,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1300,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1345,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1366,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1387,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1405,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1666,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1717,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,7 +2517,6 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
@@ -2779,15 +2676,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2793,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2835,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3194,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3355,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3382,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3684,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3761,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3799,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3930,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4010,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4068,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4092,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4122,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4567,9 +4243,6 @@
                             "VK_ANDROID_external_memory_android_hardware_buffer": {
                                 "type": "integer"
                             },
-                            "VK_ARM_rasterization_order_attachment_access": {
-                                "type": "integer"
-                            },
                             "VK_EXT_4444_formats": {
                                 "type": "integer"
                             },
@@ -4613,9 +4286,6 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
-                                "type": "integer"
-                            },
-                            "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_enable": {
@@ -4870,9 +4540,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4672,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4703,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4918,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4957,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4970,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5405,9 +5057,6 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
-                            "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
-                            },
                             "VkPhysicalDeviceDepthClipEnableFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipEnableFeaturesEXT"
                             },
@@ -5416,9 +5065,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -5429,11 +5075,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5096,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5108,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,11 +5117,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
@@ -5501,11 +5135,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5144,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5171,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5189,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5200,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5249,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5273,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5291,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5351,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5366,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5439,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5454,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5466,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5532,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5544,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5570,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5617,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5644,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5651,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5662,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5669,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5680,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5687,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5698,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5705,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5716,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5723,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5734,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5741,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5752,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5759,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5962,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +5999,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6040,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6077,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6445,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6534,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-200.json
+++ b/vulkan/profiles-0.8.1-200.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-200.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.200",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -571,15 +571,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +598,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +673,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +727,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,7 +745,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -808,7 +790,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +835,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +919,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1018,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1080,21 +1053,6 @@
             "additionalProperties": false,
             "properties": {
                 "formatRgba10x6WithoutYCbCrSampler": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "rasterizationOrderColorAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderDepthAttachmentAccess": {
-                    "type": "boolean"
-                },
-                "rasterizationOrderStencilAttachmentAccess": {
                     "type": "boolean"
                 }
             }
@@ -1300,7 +1258,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1309,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1354,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1375,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1396,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1414,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1675,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1726,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,7 +2526,6 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
@@ -2779,15 +2685,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2802,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2844,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3203,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3364,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3391,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3693,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3770,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3808,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3939,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4019,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4077,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4101,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4131,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4870,9 +4555,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4687,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4718,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4933,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4972,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +4985,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5417,9 +5084,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5429,11 +5093,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5114,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5126,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,11 +5135,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
@@ -5501,11 +5153,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5162,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5189,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5207,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5581,9 +5218,6 @@
                             },
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
-                            },
-                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
@@ -5633,11 +5267,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5291,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5309,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5369,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5384,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5457,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5472,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5484,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5550,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5562,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5588,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5635,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5662,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5669,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5680,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5687,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5698,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5705,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5716,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5723,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5734,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5741,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5752,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5759,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5770,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5777,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5980,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +6017,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6058,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6095,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6463,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6552,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-201.json
+++ b/vulkan/profiles-0.8.1-201.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-201.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.201",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -571,15 +571,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +598,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +673,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +727,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,7 +745,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -808,7 +790,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +835,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +919,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1018,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1300,7 +1273,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1324,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1369,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1390,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1411,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1429,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1690,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1741,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,7 +2541,6 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
@@ -2779,15 +2700,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2817,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2859,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3218,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3379,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3406,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3708,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3785,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3823,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3954,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4034,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4092,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4116,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4146,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4870,9 +4570,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4702,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4733,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4948,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4987,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +5000,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5417,9 +5099,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5429,11 +5108,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5129,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5141,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,11 +5150,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
@@ -5501,11 +5168,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5177,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5204,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5222,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5633,11 +5285,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5309,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5327,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5387,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5402,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5475,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5490,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5502,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5568,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5580,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5606,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5653,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5680,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5687,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5698,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5705,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5716,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5723,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5734,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5741,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5752,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5759,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5770,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5777,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5788,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5795,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5998,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +6035,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6076,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6113,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6481,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6570,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-202.json
+++ b/vulkan/profiles-0.8.1-202.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-202.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.202",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -571,15 +571,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +598,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -682,15 +673,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityMapOffset": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -745,7 +727,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,7 +745,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -808,7 +790,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -853,16 +835,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "linearColorAttachment": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +919,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1018,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1300,7 +1273,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1324,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1369,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1390,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1411,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1429,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1690,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1741,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,7 +2541,6 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
@@ -2779,15 +2700,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "fragmentDensityOffsetGranularity": {
-                    "$ref": "#/definitions/VkExtent2D"
-                }
-            }
-        },
         "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -2905,7 +2817,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2859,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3218,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3379,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3406,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3708,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3785,37 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3823,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3954,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4034,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4092,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4116,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,41 +4146,28 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
                 },
                 "priorityCount": {
                     "$ref": "#/definitions/uint32_t"
-                }
-            }
-        },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "supported": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4870,9 +4570,6 @@
                             "VK_GOOGLE_hlsl_functionality1": {
                                 "type": "integer"
                             },
-                            "VK_GOOGLE_surfaceless_query": {
-                                "type": "integer"
-                            },
                             "VK_GOOGLE_user_type": {
                                 "type": "integer"
                             },
@@ -5005,9 +4702,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4733,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5257,9 +4948,6 @@
                             "VK_NV_inherited_viewport_scissor": {
                                 "type": "integer"
                             },
-                            "VK_NV_linear_color_attachment": {
-                                "type": "integer"
-                            },
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
@@ -5299,9 +4987,6 @@
                             "VK_NV_win32_keyed_mutex": {
                                 "type": "integer"
                             },
-                            "VK_QCOM_fragment_density_map_offset": {
-                                "type": "integer"
-                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5315,9 +5000,6 @@
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
-                                "type": "integer"
-                            },
-                            "VK_VALVE_descriptor_set_host_mapping": {
                                 "type": "integer"
                             },
                             "VK_VALVE_mutable_descriptor_type": {
@@ -5417,9 +5099,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5429,11 +5108,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5453,9 +5129,6 @@
                             "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
                             },
@@ -5468,11 +5141,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,11 +5150,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
@@ -5501,11 +5168,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5513,14 +5177,8 @@
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
-                            "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
-                            },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5204,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5222,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5633,11 +5285,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5309,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5327,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5387,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5402,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5847,9 +5475,6 @@
                             "VkPhysicalDeviceFragmentDensityMap2PropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"
                             },
-                            "VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM"
-                            },
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
@@ -5865,11 +5490,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5502,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5568,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5580,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5606,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5653,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5680,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5687,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5698,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5705,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5716,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5723,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5734,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5741,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5752,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5759,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5770,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5777,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5788,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5795,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +5998,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +6035,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6076,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6113,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,14 +6481,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkVideoQueueFamilyProperties2KHR": {
                                     "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
@@ -7029,11 +6570,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-203.json
+++ b/vulkan/profiles-0.8.1-203.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-203.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.2.203",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -571,15 +571,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -607,7 +598,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceDynamicRenderingFeatures": {
+        "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -745,7 +736,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
+        "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -763,7 +754,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceImageRobustnessFeatures": {
+        "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -808,7 +799,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockFeatures": {
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -862,7 +853,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Features": {
+        "VkPhysicalDeviceMaintenance4FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -946,7 +937,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
+        "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1045,7 +1036,7 @@
                 }
             }
         },
-        "VkPhysicalDevicePrivateDataFeatures": {
+        "VkPhysicalDevicePrivateDataFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1300,7 +1291,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1351,7 +1342,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+        "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1396,7 +1387,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+        "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1417,7 +1408,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+        "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1438,7 +1429,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSynchronization2Features": {
+        "VkPhysicalDeviceSynchronization2FeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1456,7 +1447,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
+        "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1717,57 +1708,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Features": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "computeFullSubgroups": {
-                    "type": "boolean"
-                },
-                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
-                    "type": "boolean"
-                },
-                "dynamicRendering": {
-                    "type": "boolean"
-                },
-                "inlineUniformBlock": {
-                    "type": "boolean"
-                },
-                "maintenance4": {
-                    "type": "boolean"
-                },
-                "pipelineCreationCacheControl": {
-                    "type": "boolean"
-                },
-                "privateData": {
-                    "type": "boolean"
-                },
-                "robustImageAccess": {
-                    "type": "boolean"
-                },
-                "shaderDemoteToHelperInvocation": {
-                    "type": "boolean"
-                },
-                "shaderIntegerDotProduct": {
-                    "type": "boolean"
-                },
-                "shaderTerminateInvocation": {
-                    "type": "boolean"
-                },
-                "shaderZeroInitializeWorkgroupMemory": {
-                    "type": "boolean"
-                },
-                "subgroupSizeControl": {
-                    "type": "boolean"
-                },
-                "synchronization2": {
-                    "type": "boolean"
-                },
-                "textureCompressionASTC_HDR": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkPhysicalDeviceVulkanMemoryModelFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1819,7 +1759,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2619,7 +2559,6 @@
                 "VK_DRIVER_ID_MESA_RADV_KHR",
                 "VK_DRIVER_ID_MESA_TURNIP",
                 "VK_DRIVER_ID_MESA_V3DV",
-                "VK_DRIVER_ID_MESA_VENUS",
                 "VK_DRIVER_ID_MOLTENVK",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY",
                 "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
@@ -2905,7 +2844,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceInlineUniformBlockProperties": {
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -2947,7 +2886,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceMaintenance4Properties": {
+        "VkPhysicalDeviceMaintenance4PropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3306,7 +3245,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceShaderIntegerDotProductProperties": {
+        "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3467,7 +3406,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceSubgroupSizeControlProperties": {
+        "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3494,7 +3433,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceTexelBufferAlignmentProperties": {
+        "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -3796,147 +3735,6 @@
                 }
             }
         },
-        "VkPhysicalDeviceVulkan13Properties": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "integerDotProduct16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProduct8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating16BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating32BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating64BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitSignedAccelerated": {
-                    "type": "boolean"
-                },
-                "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
-                    "type": "boolean"
-                },
-                "maxBufferSize": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "maxComputeWorkgroupSubgroups": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformBlockSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxInlineUniformTotalSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "maxSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "minSubgroupSize": {
-                    "$ref": "#/definitions/uint32_t"
-                },
-                "requiredSubgroupSizeStages": {
-                    "$ref": "#/definitions/VkShaderStageFlags"
-                },
-                "storageTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "storageTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                },
-                "uniformTexelBufferOffsetAlignmentBytes": {
-                    "$ref": "#/definitions/VkDeviceSize"
-                },
-                "uniformTexelBufferOffsetSingleTexelAlignment": {
-                    "type": "boolean"
-                }
-            }
-        },
         "VkFormatFeatureFlagBits": {
             "enum": [
                 "VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
@@ -4014,65 +3812,38 @@
                 }
             }
         },
-        "VkFormatFeatureFlagBits2": {
+        "VkFormatFeatureFlagBits2KHR": {
             "enum": [
                 "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_DISJOINT_BIT",
                 "VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                 "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                 "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                 "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
@@ -4080,25 +3851,25 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
             ]
         },
-        "VkFormatFeatureFlags2": {
+        "VkFormatFeatureFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkFormatFeatureFlagBits2"
+                "$ref": "#/definitions/VkFormatFeatureFlagBits2KHR"
             },
             "uniqueItems": true
         },
-        "VkFormatProperties3": {
+        "VkFormatProperties3KHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "bufferFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "linearTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 },
                 "optimalTilingFeatures": {
-                    "$ref": "#/definitions/VkFormatFeatureFlags2"
+                    "$ref": "#/definitions/VkFormatFeatureFlags2KHR"
                 }
             }
         },
@@ -4211,11 +3982,8 @@
                 "VkFormatProperties2KHR": {
                     "$ref": "#/definitions/VkFormatProperties2"
                 },
-                "VkFormatProperties3": {
-                    "$ref": "#/definitions/VkFormatProperties3"
-                },
                 "VkFormatProperties3KHR": {
-                    "$ref": "#/definitions/VkFormatProperties3"
+                    "$ref": "#/definitions/VkFormatProperties3KHR"
                 },
                 "VkVideoDecodeH264ProfileEXT": {
                     "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
@@ -4294,82 +4062,56 @@
                 }
             }
         },
-        "VkPipelineStageFlagBits2": {
+        "VkPipelineStageFlagBits2KHR": {
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
-                "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BLIT_BIT",
                 "VK_PIPELINE_STAGE_2_BLIT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_CLEAR_BIT",
                 "VK_PIPELINE_STAGE_2_CLEAR_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT",
                 "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV",
-                "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_COPY_BIT",
                 "VK_PIPELINE_STAGE_2_COPY_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT",
                 "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_HOST_BIT",
                 "VK_PIPELINE_STAGE_2_HOST_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
-                "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
-                "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_RESOLVE_BIT",
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT",
                 "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_TRANSFER_BIT",
                 "VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT",
-                "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT_KHR",
-                "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"
             ]
         },
-        "VkPipelineStageFlags2": {
+        "VkPipelineStageFlags2KHR": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/VkPipelineStageFlagBits2"
+                "$ref": "#/definitions/VkPipelineStageFlagBits2KHR"
             },
             "uniqueItems": true
         },
@@ -4378,7 +4120,7 @@
             "additionalProperties": false,
             "properties": {
                 "checkpointExecutionStageMask": {
-                    "$ref": "#/definitions/VkPipelineStageFlags2"
+                    "$ref": "#/definitions/VkPipelineStageFlags2KHR"
                 }
             }
         },
@@ -4402,7 +4144,6 @@
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
-                "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
@@ -4433,26 +4174,22 @@
                 }
             }
         },
-        "VkQueueGlobalPriorityKHR": {
+        "VkQueueGlobalPriorityEXT": {
             "enum": [
                 "VK_QUEUE_GLOBAL_PRIORITY_HIGH_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_LOW_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR",
                 "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT",
-                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR"
+                "VK_QUEUE_GLOBAL_PRIORITY_REALTIME_EXT"
             ]
         },
-        "VkQueueFamilyGlobalPriorityPropertiesKHR": {
+        "VkQueueFamilyGlobalPriorityPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "priorities": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/VkQueueGlobalPriorityKHR"
+                        "$ref": "#/definitions/VkQueueGlobalPriorityEXT"
                     },
                     "uniqueItems": false,
                     "maxItems": 16
@@ -5005,9 +4742,6 @@
                             "VK_KHR_get_surface_capabilities2": {
                                 "type": "integer"
                             },
-                            "VK_KHR_global_priority": {
-                                "type": "integer"
-                            },
                             "VK_KHR_image_format_list": {
                                 "type": "integer"
                             },
@@ -5039,9 +4773,6 @@
                                 "type": "integer"
                             },
                             "VK_KHR_pipeline_library": {
-                                "type": "integer"
-                            },
-                            "VK_KHR_portability_enumeration": {
                                 "type": "integer"
                             },
                             "VK_KHR_portability_subset": {
@@ -5317,9 +5048,6 @@
                             "VK_QNX_screen_surface": {
                                 "type": "integer"
                             },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
                             "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
@@ -5417,9 +5145,6 @@
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
                             },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
-                            },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
                             },
@@ -5429,11 +5154,8 @@
                             "VkPhysicalDeviceDiagnosticsConfigFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDiagnosticsConfigFeaturesNV"
                             },
-                            "VkPhysicalDeviceDynamicRenderingFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
-                            },
                             "VkPhysicalDeviceDynamicRenderingFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceDynamicRenderingFeaturesKHR"
                             },
                             "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
@@ -5468,11 +5190,8 @@
                             "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateFeaturesKHR"
                             },
-                            "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
-                            },
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
+                                "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"
                             },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
@@ -5480,11 +5199,8 @@
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
-                            "VkPhysicalDeviceImageRobustnessFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
-                            },
                             "VkPhysicalDeviceImageRobustnessFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageViewMinLodFeaturesEXT"
@@ -5501,11 +5217,8 @@
                             "VkPhysicalDeviceInheritedViewportScissorFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInheritedViewportScissorFeaturesNV"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
                             },
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
@@ -5516,11 +5229,8 @@
                             "VkPhysicalDeviceLinearColorAttachmentFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLinearColorAttachmentFeaturesNV"
                             },
-                            "VkPhysicalDeviceMaintenance4Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
-                            },
                             "VkPhysicalDeviceMaintenance4FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4FeaturesKHR"
                             },
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
@@ -5546,11 +5256,8 @@
                             "VkPhysicalDevicePerformanceQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryFeaturesKHR"
                             },
-                            "VkPhysicalDevicePipelineCreationCacheControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
-                            },
                             "VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT"
                             },
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
@@ -5567,11 +5274,8 @@
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
                             },
-                            "VkPhysicalDevicePrivateDataFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
-                            },
                             "VkPhysicalDevicePrivateDataFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
+                                "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeaturesEXT"
                             },
                             "VkPhysicalDeviceProtectedMemoryFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
@@ -5633,11 +5337,8 @@
                             "VkPhysicalDeviceShaderClockFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderClockFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderDrawParametersFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
@@ -5660,11 +5361,8 @@
                             "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR"
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
@@ -5681,38 +5379,26 @@
                             "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR"
                             },
-                            "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
-                            },
                             "VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR"
                             },
                             "VkPhysicalDeviceShadingRateImageFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
-                            "VkPhysicalDeviceSynchronization2Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
-                            },
                             "VkPhysicalDeviceSynchronization2FeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2Features"
+                                "$ref": "#/definitions/VkPhysicalDeviceSynchronization2FeaturesKHR"
                             },
                             "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT"
                             },
-                            "VkPhysicalDeviceTextureCompressionASTCHDRFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
-                            },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5753,9 +5439,6 @@
                             "VkPhysicalDeviceVulkan12Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Features"
                             },
-                            "VkPhysicalDeviceVulkan13Features": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Features"
-                            },
                             "VkPhysicalDeviceVulkanMemoryModelFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeatures"
                             },
@@ -5771,11 +5454,8 @@
                             "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"
                             },
-                            "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
-                            },
                             "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures"
+                                "$ref": "#/definitions/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"
                             }
                         }
                     },
@@ -5865,11 +5545,8 @@
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
-                            "VkPhysicalDeviceInlineUniformBlockProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
-                            },
                             "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
                             },
                             "VkPhysicalDeviceLineRasterizationPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationPropertiesEXT"
@@ -5880,11 +5557,8 @@
                             "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
                             },
-                            "VkPhysicalDeviceMaintenance4Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
-                            },
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance4PropertiesKHR"
                             },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
@@ -5949,11 +5623,8 @@
                             "VkPhysicalDeviceShaderCorePropertiesAMD": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
                             },
-                            "VkPhysicalDeviceShaderIntegerDotProductProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
-                            },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
-                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -5964,20 +5635,14 @@
                             "VkPhysicalDeviceSubgroupProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
                             },
-                            "VkPhysicalDeviceSubgroupSizeControlProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
-                            },
                             "VkPhysicalDeviceSubgroupSizeControlPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingPropertiesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingPropertiesHUAWEI"
                             },
-                            "VkPhysicalDeviceTexelBufferAlignmentProperties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
-                            },
                             "VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT": {
-                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentProperties"
+                                "$ref": "#/definitions/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreProperties"
@@ -5996,9 +5661,6 @@
                             },
                             "VkPhysicalDeviceVulkan12Properties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceVulkan12Properties"
-                            },
-                            "VkPhysicalDeviceVulkan13Properties": {
-                                "$ref": "#/definitions/VkPhysicalDeviceVulkan13Properties"
                             }
                         }
                     },
@@ -6046,13 +5708,7 @@
                             "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_A4B4G4R4_UNORM_PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_A4B4G4R4_UNORM_PACK16_EXT": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_A4R4G4B4_UNORM_PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_A4R4G4B4_UNORM_PACK16_EXT": {
@@ -6079,9 +5735,6 @@
                             "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6089,9 +5742,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x5_SFLOAT_BLOCK_EXT": {
@@ -6103,9 +5753,6 @@
                             "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_10x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6113,9 +5760,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK_EXT": {
@@ -6127,9 +5771,6 @@
                             "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6137,9 +5778,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT": {
@@ -6151,9 +5789,6 @@
                             "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6161,9 +5796,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x4_SFLOAT_BLOCK_EXT": {
@@ -6175,9 +5807,6 @@
                             "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_5x5_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6185,9 +5814,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x5_SFLOAT_BLOCK_EXT": {
@@ -6199,9 +5825,6 @@
                             "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6209,9 +5832,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x5_SFLOAT_BLOCK_EXT": {
@@ -6223,9 +5843,6 @@
                             "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_ASTC_8x6_SFLOAT_BLOCK_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6233,9 +5850,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_ASTC_8x8_SFLOAT_BLOCK_EXT": {
@@ -6439,9 +6053,6 @@
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6479,9 +6090,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT": {
@@ -6523,9 +6131,6 @@
                             "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
                                 "$ref": "#/definitions/formatProperties"
                             },
-                            "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
                             "VK_FORMAT_G16_B16R16_2PLANE_444_UNORM_EXT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6563,9 +6168,6 @@
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
-                                "$ref": "#/definitions/formatProperties"
-                            },
-                            "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM": {
                                 "$ref": "#/definitions/formatProperties"
                             },
                             "VK_FORMAT_G8_B8R8_2PLANE_444_UNORM_EXT": {
@@ -6934,11 +6536,8 @@
                                 "VkQueueFamilyCheckpointPropertiesNV": {
                                     "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
                                 },
-                                "VkQueueFamilyGlobalPriorityPropertiesKHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
-                                },
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
-                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
+                                    "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesEXT"
                                 },
                                 "VkQueueFamilyQueryResultStatusProperties2KHR": {
                                     "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
@@ -7029,11 +6628,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-204.json
+++ b/vulkan/profiles-0.8.1-204.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-204.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.204",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -567,15 +567,6 @@
                     "type": "boolean"
                 },
                 "shaderUniformTexelBufferArrayNonUniformIndexing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
                     "type": "boolean"
                 }
             }
@@ -5041,9 +5032,6 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
                             "VK_KHR_portability_subset": {
                                 "type": "integer"
                             },
@@ -5317,9 +5305,6 @@
                             "VK_QNX_screen_surface": {
                                 "type": "integer"
                             },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
                             "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
@@ -5416,9 +5401,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -7029,11 +7011,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-205.json
+++ b/vulkan/profiles-0.8.1-205.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-205.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.205",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -567,15 +567,6 @@
                     "type": "boolean"
                 },
                 "shaderUniformTexelBufferArrayNonUniformIndexing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
                     "type": "boolean"
                 }
             }
@@ -5041,9 +5032,6 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
                             "VK_KHR_portability_subset": {
                                 "type": "integer"
                             },
@@ -5317,9 +5305,6 @@
                             "VK_QNX_screen_surface": {
                                 "type": "integer"
                             },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
                             "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
@@ -5416,9 +5401,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -7029,11 +7011,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-206.json
+++ b/vulkan/profiles-0.8.1-206.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-206.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.206",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -567,15 +567,6 @@
                     "type": "boolean"
                 },
                 "shaderUniformTexelBufferArrayNonUniformIndexing": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "descriptorSetHostMapping": {
                     "type": "boolean"
                 }
             }
@@ -5041,9 +5032,6 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
                             "VK_KHR_portability_subset": {
                                 "type": "integer"
                             },
@@ -5317,9 +5305,6 @@
                             "VK_QNX_screen_surface": {
                                 "type": "integer"
                             },
-                            "VK_VALVE_descriptor_set_host_mapping": {
-                                "type": "integer"
-                            },
                             "VK_VALVE_mutable_descriptor_type": {
                                 "type": "integer"
                             }
@@ -5416,9 +5401,6 @@
                             },
                             "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeatures"
-                            },
-                            "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE"
                             },
                             "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV"
@@ -7029,11 +7011,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-207.json
+++ b/vulkan/profiles-0.8.1-207.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-207.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.207",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -5041,9 +5041,6 @@
                             "VK_KHR_pipeline_library": {
                                 "type": "integer"
                             },
-                            "VK_KHR_portability_enumeration": {
-                                "type": "integer"
-                            },
                             "VK_KHR_portability_subset": {
                                 "type": "integer"
                             },
@@ -7029,11 +7026,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-208.json
+++ b/vulkan/profiles-0.8.1-208.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.208.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.208",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -7029,11 +7029,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-209.json
+++ b/vulkan/profiles-0.8.1-209.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-209.json#",
     "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
     "additionalProperties": true,
     "required": [
@@ -7029,11 +7029,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-210.json
+++ b/vulkan/profiles-0.8.1-210.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-210.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.210",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -754,6 +754,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1041,6 +1050,21 @@
                     "type": "boolean"
                 },
                 "primitiveTopologyPatchListRestart": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
                     "type": "boolean"
                 }
             }
@@ -2869,6 +2893,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4678,6 +4714,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4739,6 +4778,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -5474,6 +5516,9 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
@@ -5566,6 +5611,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5858,6 +5906,9 @@
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7080,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-211.json
+++ b/vulkan/profiles-0.8.1-211.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-211.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.211",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -754,11 +754,32 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
                     "type": "boolean"
                 }
             }
@@ -1041,6 +1062,21 @@
                     "type": "boolean"
                 },
                 "primitiveTopologyPatchListRestart": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
                     "type": "boolean"
                 }
             }
@@ -2869,6 +2905,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4678,6 +4726,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4736,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4739,6 +4793,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -5474,11 +5531,17 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5566,6 +5629,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5858,6 +5924,9 @@
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7098,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-212.json
+++ b/vulkan/profiles-0.8.1-212.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-212.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.212",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -754,11 +754,32 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
                     "type": "boolean"
                 }
             }
@@ -1041,6 +1062,21 @@
                     "type": "boolean"
                 },
                 "primitiveTopologyPatchListRestart": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
                     "type": "boolean"
                 }
             }
@@ -2869,6 +2905,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4678,6 +4726,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4736,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4739,6 +4793,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -5474,11 +5531,17 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5566,6 +5629,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5858,6 +5924,9 @@
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7098,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-213.json
+++ b/vulkan/profiles-0.8.1-213.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-213.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.213",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -964,6 +1003,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1045,6 +1093,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1167,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1425,6 +1500,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2869,6 +2953,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4298,6 +4394,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4678,6 +4775,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4785,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4735,10 +4844,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4908,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5057,6 +5175,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5474,11 +5595,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5555,6 +5688,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5702,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5726,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5695,6 +5837,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5858,6 +6003,9 @@
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7177,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-214.json
+++ b/vulkan/profiles-0.8.1-214.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-214.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.214",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -964,6 +1003,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1045,6 +1093,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1167,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1393,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1425,6 +1509,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2869,6 +2962,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4298,6 +4403,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4546,6 +4652,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4678,6 +4787,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4797,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4735,10 +4856,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4920,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -5057,6 +5187,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5474,11 +5607,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5555,6 +5700,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5714,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5738,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5799,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesEXT"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5695,6 +5852,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5858,6 +6018,9 @@
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7192,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-215.json
+++ b/vulkan/profiles-0.8.1-215.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-215.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.215",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -964,6 +1003,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1045,6 +1093,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1167,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1393,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1425,6 +1509,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2803,6 +2896,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2967,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -4298,6 +4412,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4546,6 +4661,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4678,6 +4796,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4806,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4735,10 +4865,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4929,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5129,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5199,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5601,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5622,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5555,6 +5715,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5729,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5753,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5814,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5695,6 +5867,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6028,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7210,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-216.json
+++ b/vulkan/profiles-0.8.1-216.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-216.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.216",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -964,6 +1003,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1045,6 +1093,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1167,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1393,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1425,6 +1509,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2803,6 +2896,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2967,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -4298,6 +4412,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4546,6 +4661,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4678,6 +4796,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4806,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4735,10 +4865,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4929,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5129,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5199,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5601,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5622,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5555,6 +5715,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5729,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5753,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5814,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5695,6 +5867,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6028,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7210,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-217.json
+++ b/vulkan/profiles-0.8.1-217.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-217.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.217",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -925,6 +964,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -960,6 +1008,15 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1102,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1176,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1402,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1425,6 +1518,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2803,6 +2905,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2976,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -4298,6 +4421,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4546,6 +4670,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4678,6 +4805,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4815,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4853,16 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4880,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4944,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5144,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5214,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5616,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5637,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5540,6 +5715,9 @@
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
                             },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
+                            },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
                             },
@@ -5555,6 +5733,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5747,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5771,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5832,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5695,6 +5885,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6046,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7228,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-218.json
+++ b/vulkan/profiles-0.8.1-218.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-218.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.218",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -925,6 +964,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -960,6 +1008,15 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1102,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1176,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1402,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1425,6 +1518,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2803,6 +2905,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2976,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -4102,102 +4225,6 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
-                }
-            }
-        },
         "formatProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -4216,21 +4243,6 @@
                 },
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
-                },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
                 }
             }
         },
@@ -4298,6 +4310,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4479,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4566,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4703,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4713,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4751,16 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4778,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4793,6 +4842,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5042,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5112,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5514,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5535,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5540,6 +5613,9 @@
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
                             },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
+                            },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
                             },
@@ -5555,6 +5631,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5645,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5669,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5730,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5695,6 +5783,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +5944,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -7029,11 +7126,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-219.json
+++ b/vulkan/profiles-0.8.1-219.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-219.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.219",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +940,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +969,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1017,15 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1111,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1185,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1411,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1467,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1425,6 +1536,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2733,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2924,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2995,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -3399,6 +3541,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4102,99 +4258,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4286,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4355,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4524,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4611,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4748,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4758,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4796,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4826,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4877,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +4893,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5093,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5163,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5565,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5586,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5655,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5666,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5685,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5699,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5723,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5784,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5810,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5695,6 +5840,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6001,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -5954,6 +6108,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7186,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-220.json
+++ b/vulkan/profiles-0.8.1-220.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-220.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.219",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +940,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +969,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1017,15 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1111,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1185,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1411,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1467,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1425,6 +1536,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2733,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2924,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +2995,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -3399,6 +3541,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4102,99 +4258,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4286,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4355,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4524,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4611,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4748,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4758,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4796,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4826,16 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4877,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +4893,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5093,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5163,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5565,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5586,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5655,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5666,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5685,9 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5699,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5723,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5784,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5810,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5695,6 +5840,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6001,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -5954,6 +6108,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7186,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-221.json
+++ b/vulkan/profiles-0.8.1-221.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-222.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.221",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,50 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +940,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +969,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1017,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1120,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1194,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1420,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1476,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1425,6 +1545,15 @@
                     "type": "boolean"
                 },
                 "subgroupSizeControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2742,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2933,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2865,6 +3004,18 @@
                     "$ref": "#/definitions/VkExtent2D"
                 },
                 "primitiveFragmentShadingRateWithMultipleViewports": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
                     "type": "boolean"
                 }
             }
@@ -3065,6 +3216,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3584,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4102,99 +4301,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4329,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4398,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4567,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4654,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4791,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4801,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4839,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4869,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4923,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +4939,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5139,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5209,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5456,8 +5611,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5632,23 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5701,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5712,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5731,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5748,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5772,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5833,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5859,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5695,6 +5889,9 @@
                             },
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
+                            },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
                             },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
@@ -5853,11 +6050,17 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
                             },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
@@ -5907,6 +6110,9 @@
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
                             },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
+                            },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
                             },
@@ -5954,6 +6160,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7238,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-222.json
+++ b/vulkan/profiles-0.8.1-222.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-222.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.222",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +955,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +984,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1032,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1135,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1209,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1435,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1491,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1564,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1605,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2766,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2957,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3032,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3077,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -3065,6 +3258,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3626,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4262,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4320,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4347,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4375,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4444,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4613,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4700,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4837,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4847,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4885,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4915,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4969,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +4985,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5185,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5255,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5503,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5312,6 +5516,9 @@
                                 "type": "integer"
                             },
                             "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_tile_properties": {
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
@@ -5456,8 +5663,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5684,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5756,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5767,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5786,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5803,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5827,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5888,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5914,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +5945,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +5965,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6108,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5906,6 +6170,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6221,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7299,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-223.json
+++ b/vulkan/profiles-0.8.1-223.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-223.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.223",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -691,7 +691,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +754,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +955,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +984,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1032,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1135,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1209,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1435,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1491,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1564,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1605,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2766,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2957,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3032,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3077,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -3065,6 +3258,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3626,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4262,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4320,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4347,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4375,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4444,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4613,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4544,6 +4700,9 @@
                                 "type": "integer"
                             },
                             "VK_AMD_shader_core_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
                                 "type": "integer"
                             },
                             "VK_AMD_shader_explicit_vertex_parameter": {
@@ -4678,6 +4837,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4847,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4885,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4915,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4969,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +4985,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5185,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5255,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5503,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5312,6 +5516,9 @@
                                 "type": "integer"
                             },
                             "VK_QCOM_rotated_copy_commands": {
+                                "type": "integer"
+                            },
+                            "VK_QCOM_tile_properties": {
                                 "type": "integer"
                             },
                             "VK_QNX_screen_surface": {
@@ -5456,8 +5663,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5684,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5756,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5767,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5786,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5803,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5827,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5888,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5914,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +5945,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +5965,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6108,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5906,6 +6170,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6221,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7299,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-224.json
+++ b/vulkan/profiles-0.8.1-224.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-224.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.224",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -339,6 +339,24 @@
                     "type": "boolean"
                 },
                 "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +709,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +772,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +973,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +1002,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1050,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1153,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1104,6 +1227,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1453,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1509,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1582,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1623,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2784,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2975,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3050,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3095,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -3065,6 +3276,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3644,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4280,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4338,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4365,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4393,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4462,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4466,10 +4631,19 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4546,6 +4720,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4580,6 +4757,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_attachment_feedback_loop_layout": {
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
@@ -4678,6 +4858,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4868,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4906,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4936,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4780,6 +4990,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5006,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5206,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5276,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5524,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5539,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5359,6 +5590,12 @@
                             },
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
                             },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
@@ -5456,8 +5693,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5714,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5786,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5797,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5816,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5833,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5587,6 +5857,9 @@
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5918,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5944,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +5975,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +5995,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6138,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5906,6 +6200,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6251,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -7029,11 +7329,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-225.json
+++ b/vulkan/profiles-0.8.1-225.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-225.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.225",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -339,6 +339,24 @@
                     "type": "boolean"
                 },
                 "descriptorBindingAccelerationStructureUpdateAfterBind": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +709,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +772,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -901,6 +973,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -921,6 +1002,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1050,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1153,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1084,7 +1207,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1227,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1453,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1509,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1582,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1623,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2613,6 +2784,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2975,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3050,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3095,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -3065,6 +3276,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3644,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4280,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4338,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4365,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4393,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4462,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4462,14 +4627,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +4652,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +4720,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4580,6 +4757,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_attachment_feedback_loop_layout": {
                                 "type": "integer"
                             },
                             "VK_EXT_blend_operation_advanced": {
@@ -4678,6 +4858,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +4868,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +4906,19 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +4936,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +4958,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +4993,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5009,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5209,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5279,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5527,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5542,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5359,6 +5593,12 @@
                             },
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
                             },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
@@ -5456,8 +5696,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5717,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5531,6 +5789,9 @@
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
@@ -5539,6 +5800,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5819,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5836,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +5855,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +5924,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +5950,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +5981,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6001,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6144,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5906,6 +6206,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6257,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6940,11 +7246,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7335,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-226.json
+++ b/vulkan/profiles-0.8.1-226.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-226.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.226",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,27 +57,15 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer"
         },
         "uint64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer",
+            "minimum": 0
         },
         "VkDeviceSize": {
-            "$ref": "#/definitions/uint64_t"
+            "type": "integer",
+            "minimum": 0
         },
         "char": {
             "type": "string"
@@ -86,7 +74,8 @@
             "type": "number"
         },
         "size_t": {
-            "$ref": "#/definitions/uint32_t"
+            "type": "integer",
+            "minimum": 0
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -343,6 +332,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -483,6 +490,15 @@
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClampZeroOne": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +707,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +770,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -880,6 +950,27 @@
                 }
             }
         },
+        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "meshShaderQueries": {
+                    "type": "boolean"
+                },
+                "multiviewMeshShader": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRateMeshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMeshShaderFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -897,6 +988,15 @@
             "additionalProperties": false,
             "properties": {
                 "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -921,6 +1021,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1069,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1172,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1084,7 +1226,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1246,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1472,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1528,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1601,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1642,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2380,12 +2570,14 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
                 "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2613,6 +2805,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +2996,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3071,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3116,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2953,6 +3185,116 @@
             "properties": {
                 "maxBufferSize": {
                     "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "prefersCompactPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersCompactVertexOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationVertexOutput": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3065,6 +3407,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3775,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4411,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4469,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4496,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4524,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4593,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4335,6 +4631,7 @@
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
@@ -4346,6 +4643,7 @@
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
@@ -4401,12 +4699,14 @@
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4462,14 +4762,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +4787,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +4855,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4582,6 +4894,9 @@
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
+                            "VK_EXT_attachment_feedback_loop_layout": {
+                                "type": "integer"
+                            },
                             "VK_EXT_blend_operation_advanced": {
                                 "type": "integer"
                             },
@@ -4613,6 +4928,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clamp_zero_one": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_control": {
@@ -4678,6 +4996,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +5006,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4714,10 +5044,22 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +5077,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +5099,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +5134,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5150,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5350,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5420,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5668,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5683,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5360,6 +5735,12 @@
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
                             },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
@@ -5404,6 +5785,9 @@
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
@@ -5456,8 +5840,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5861,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5525,11 +5927,17 @@
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
                             },
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -5539,6 +5947,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5966,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5983,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +6002,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +6071,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +6097,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +6128,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6148,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6291,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5886,6 +6333,9 @@
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
+                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
                             },
@@ -5906,6 +6356,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6407,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6940,11 +7396,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7485,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-227.json
+++ b/vulkan/profiles-0.8.1-227.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-227.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.227",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,27 +57,15 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer"
         },
         "uint64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer",
+            "minimum": 0
         },
         "VkDeviceSize": {
-            "$ref": "#/definitions/uint64_t"
+            "type": "integer",
+            "minimum": 0
         },
         "char": {
             "type": "string"
@@ -86,7 +74,8 @@
             "type": "number"
         },
         "size_t": {
-            "$ref": "#/definitions/uint32_t"
+            "type": "integer",
+            "minimum": 0
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -343,6 +332,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -483,6 +490,15 @@
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClampZeroOne": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +707,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +770,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -829,6 +899,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "legacyDithering": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -880,6 +959,27 @@
                 }
             }
         },
+        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "meshShaderQueries": {
+                    "type": "boolean"
+                },
+                "multiviewMeshShader": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRateMeshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMeshShaderFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -897,6 +997,15 @@
             "additionalProperties": false,
             "properties": {
                 "multiDraw": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
                     "type": "boolean"
                 }
             }
@@ -921,6 +1030,15 @@
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1078,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1181,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1084,7 +1235,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1255,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1481,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1537,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1610,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1651,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2380,12 +2579,14 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
                 "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2613,6 +2814,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +3005,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3080,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3125,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2953,6 +3194,116 @@
             "properties": {
                 "maxBufferSize": {
                     "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "prefersCompactPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersCompactVertexOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationVertexOutput": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3065,6 +3416,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3784,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4420,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4478,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4505,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4533,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4602,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4335,6 +4640,7 @@
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
@@ -4346,6 +4652,7 @@
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
@@ -4401,12 +4708,14 @@
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4462,14 +4771,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +4796,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +4864,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4582,6 +4903,9 @@
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
+                            "VK_EXT_attachment_feedback_loop_layout": {
+                                "type": "integer"
+                            },
                             "VK_EXT_blend_operation_advanced": {
                                 "type": "integer"
                             },
@@ -4613,6 +4937,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clamp_zero_one": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_control": {
@@ -4678,6 +5005,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +5015,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4702,6 +5041,9 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
+                            "VK_EXT_legacy_dithering": {
+                                "type": "integer"
+                            },
                             "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
@@ -4714,10 +5056,22 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +5089,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +5111,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +5146,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5162,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5362,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5432,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5680,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5695,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5360,6 +5747,12 @@
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
                             },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
@@ -5404,6 +5797,9 @@
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
@@ -5456,8 +5852,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5873,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5510,6 +5924,9 @@
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
+                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                            },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
@@ -5525,11 +5942,17 @@
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
                             },
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -5539,6 +5962,9 @@
                             },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5981,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +5998,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +6017,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +6086,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +6112,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +6143,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6163,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6306,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5886,6 +6348,9 @@
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
+                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
                             },
@@ -5906,6 +6371,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6422,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6940,11 +7411,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7500,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-228.json
+++ b/vulkan/profiles-0.8.1-228.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-228.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.228",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,27 +57,15 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer"
         },
         "uint64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer",
+            "minimum": 0
         },
         "VkDeviceSize": {
-            "$ref": "#/definitions/uint64_t"
+            "type": "integer",
+            "minimum": 0
         },
         "char": {
             "type": "string"
@@ -86,7 +74,8 @@
             "type": "number"
         },
         "size_t": {
-            "$ref": "#/definitions/uint32_t"
+            "type": "integer",
+            "minimum": 0
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -343,6 +332,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -483,6 +490,15 @@
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClampZeroOne": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +707,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +770,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -829,6 +899,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "legacyDithering": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -880,6 +959,27 @@
                 }
             }
         },
+        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "meshShaderQueries": {
+                    "type": "boolean"
+                },
+                "multiviewMeshShader": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRateMeshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMeshShaderFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -901,6 +1001,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -916,11 +1025,20 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1078,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1181,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1084,7 +1235,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1255,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1481,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1537,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1610,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1651,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2380,12 +2579,14 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
                 "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2613,6 +2814,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +3005,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3080,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3125,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2953,6 +3194,116 @@
             "properties": {
                 "maxBufferSize": {
                     "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "prefersCompactPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersCompactVertexOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationVertexOutput": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3065,6 +3416,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3784,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4420,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4478,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4505,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4533,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4602,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4335,6 +4640,7 @@
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
@@ -4346,6 +4652,7 @@
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
@@ -4401,12 +4708,14 @@
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4462,14 +4771,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +4796,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +4864,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4582,6 +4903,9 @@
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
+                            "VK_EXT_attachment_feedback_loop_layout": {
+                                "type": "integer"
+                            },
                             "VK_EXT_blend_operation_advanced": {
                                 "type": "integer"
                             },
@@ -4613,6 +4937,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clamp_zero_one": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_control": {
@@ -4678,6 +5005,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +5015,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4702,6 +5041,9 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
+                            "VK_EXT_legacy_dithering": {
+                                "type": "integer"
+                            },
                             "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
@@ -4714,10 +5056,25 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_mutable_descriptor_type": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +5092,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +5114,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +5149,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5165,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5365,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5435,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5683,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5698,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5360,6 +5750,12 @@
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
                             },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
@@ -5404,6 +5800,9 @@
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
@@ -5456,8 +5855,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5876,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5510,6 +5927,9 @@
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
+                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                            },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
@@ -5525,11 +5945,17 @@
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
                             },
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -5537,8 +5963,14 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5987,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +6004,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +6023,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +6092,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +6118,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +6149,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6169,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6312,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5886,6 +6354,9 @@
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
+                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
                             },
@@ -5906,6 +6377,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6428,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6940,11 +7417,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7506,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-229.json
+++ b/vulkan/profiles-0.8.1-229.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-229.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.229",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,27 +57,15 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer"
         },
         "uint64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer",
+            "minimum": 0
         },
         "VkDeviceSize": {
-            "$ref": "#/definitions/uint64_t"
+            "type": "integer",
+            "minimum": 0
         },
         "char": {
             "type": "string"
@@ -86,7 +74,8 @@
             "type": "number"
         },
         "size_t": {
-            "$ref": "#/definitions/uint32_t"
+            "type": "integer",
+            "minimum": 0
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -343,6 +332,24 @@
                 }
             }
         },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -483,6 +490,15 @@
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClampZeroOne": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +707,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +770,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -829,6 +899,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "legacyDithering": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -880,6 +959,27 @@
                 }
             }
         },
+        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "meshShaderQueries": {
+                    "type": "boolean"
+                },
+                "multiviewMeshShader": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRateMeshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMeshShaderFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -901,6 +1001,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -916,11 +1025,20 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1078,24 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1045,6 +1181,21 @@
                 }
             }
         },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePrivateDataFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -1084,7 +1235,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1255,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1481,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1537,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1610,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1651,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2380,12 +2579,14 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
                 "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2613,6 +2814,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2803,6 +3005,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3080,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3125,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2953,6 +3194,116 @@
             "properties": {
                 "maxBufferSize": {
                     "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "prefersCompactPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersCompactVertexOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationVertexOutput": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3065,6 +3416,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +3784,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4420,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4077,7 +4478,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4505,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4533,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4298,6 +4602,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4335,6 +4640,7 @@
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
@@ -4346,6 +4652,7 @@
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
@@ -4401,12 +4708,14 @@
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4462,14 +4771,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +4796,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +4864,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4582,6 +4903,9 @@
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
+                            "VK_EXT_attachment_feedback_loop_layout": {
+                                "type": "integer"
+                            },
                             "VK_EXT_blend_operation_advanced": {
                                 "type": "integer"
                             },
@@ -4613,6 +4937,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_clamp_zero_one": {
                                 "type": "integer"
                             },
                             "VK_EXT_depth_clip_control": {
@@ -4678,6 +5005,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +5015,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4702,6 +5041,9 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
+                            "VK_EXT_legacy_dithering": {
+                                "type": "integer"
+                            },
                             "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
@@ -4714,10 +5056,25 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_mutable_descriptor_type": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +5092,19 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +5114,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +5149,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5165,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5365,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5435,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5302,6 +5683,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5698,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5360,6 +5750,12 @@
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
                             },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
+                            },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
                             },
@@ -5404,6 +5800,9 @@
                             },
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
                             },
                             "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
@@ -5456,8 +5855,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +5876,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5510,6 +5927,9 @@
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
+                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                            },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
@@ -5525,11 +5945,17 @@
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
                             },
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -5537,8 +5963,14 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,6 +5987,12 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
                             },
@@ -5566,6 +6004,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +6023,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +6092,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +6118,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +6149,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6169,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5853,17 +6312,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5886,6 +6354,9 @@
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
+                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
                             },
@@ -5906,6 +6377,9 @@
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6428,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6940,11 +7417,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7506,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-230.json
+++ b/vulkan/profiles-0.8.1-230.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.209.json#",
-    "title": "Vulkan Profiles Schema for Vulkan 1.3.209",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-230.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.3.230",
     "additionalProperties": true,
     "required": [
         "capabilities",
@@ -57,27 +57,15 @@
             "maximum": 4294967295
         },
         "int64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer"
         },
         "uint64_t": {
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "integer"
-                }
-            ]
+            "type": "integer",
+            "minimum": 0
         },
         "VkDeviceSize": {
-            "$ref": "#/definitions/uint64_t"
+            "type": "integer",
+            "minimum": 0
         },
         "char": {
             "type": "string"
@@ -86,7 +74,8 @@
             "type": "number"
         },
         "size_t": {
-            "$ref": "#/definitions/uint32_t"
+            "type": "integer",
+            "minimum": 0
         },
         "VkPhysicalDeviceFeatures": {
             "type": "object",
@@ -343,6 +332,33 @@
                 }
             }
         },
+        "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "reportAddressBinding": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "amigoProfiling": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attachmentFeedbackLoopLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -483,6 +499,15 @@
             "additionalProperties": false,
             "properties": {
                 "dedicatedAllocationImageAliasing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depthClampZeroOne": {
                     "type": "boolean"
                 }
             }
@@ -640,6 +665,105 @@
                 }
             }
         },
+        "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "extendedDynamicState3AlphaToCoverageEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3AlphaToOneEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ColorBlendAdvanced": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ColorBlendEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ColorBlendEquation": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ColorWriteMask": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ConservativeRasterizationMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageModulationMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageModulationTable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageModulationTableEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageReductionMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageToColorEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3CoverageToColorLocation": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3DepthClampEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3DepthClipEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3DepthClipNegativeOneToOne": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ExtraPrimitiveOverestimationSize": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3LineRasterizationMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3LineStippleEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3LogicOpEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3PolygonMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ProvokingVertexMode": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3RasterizationSamples": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3RasterizationStream": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3RepresentativeFragmentTestEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3SampleLocationsEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3SampleMask": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ShadingRateImageEnable": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3TessellationDomainOrigin": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ViewportSwizzle": {
+                    "type": "boolean"
+                },
+                "extendedDynamicState3ViewportWScalingEnable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -654,6 +778,18 @@
             "additionalProperties": false,
             "properties": {
                 "externalMemoryRDMA": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFaultFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceFault": {
+                    "type": "boolean"
+                },
+                "deviceFaultVendorBinary": {
                     "type": "boolean"
                 }
             }
@@ -691,7 +827,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -754,11 +890,65 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibrary": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceHostQueryResetFeatures": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "hostQueryReset": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image2DViewOf3D": {
+                    "type": "boolean"
+                },
+                "sampler2DViewOf3D": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageCompressionControlSwapchain": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "textureBlockMatch": {
+                    "type": "boolean"
+                },
+                "textureBoxFilter": {
+                    "type": "boolean"
+                },
+                "textureSampleWeighted": {
                     "type": "boolean"
                 }
             }
@@ -829,6 +1019,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "legacyDithering": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -880,6 +1079,27 @@
                 }
             }
         },
+        "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "meshShaderQueries": {
+                    "type": "boolean"
+                },
+                "multiviewMeshShader": {
+                    "type": "boolean"
+                },
+                "primitiveFragmentShadingRateMeshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMeshShaderFeaturesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -901,6 +1121,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multisampledRenderToSingleSampled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceMultiviewFeatures": {
             "type": "object",
             "additionalProperties": false,
@@ -916,11 +1145,44 @@
                 }
             }
         },
-        "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
+        "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "mutableDescriptorType": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "nonSeamlessCubeMap": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "micromap": {
+                    "type": "boolean"
+                },
+                "micromapCaptureReplay": {
+                    "type": "boolean"
+                },
+                "micromapHostCommands": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceOpticalFlowFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "opticalFlow": {
                     "type": "boolean"
                 }
             }
@@ -960,6 +1222,33 @@
             "additionalProperties": false,
             "properties": {
                 "pipelineExecutableInfo": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelinePropertiesIdentifier": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineProtectedAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pipelineRobustness": {
                     "type": "boolean"
                 }
             }
@@ -1015,6 +1304,15 @@
                 }
             }
         },
+        "VkPhysicalDevicePresentBarrierFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "presentBarrier": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDevicePresentIdFeaturesKHR": {
             "type": "object",
             "additionalProperties": false,
@@ -1041,6 +1339,21 @@
                     "type": "boolean"
                 },
                 "primitiveTopologyPatchListRestart": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "primitivesGeneratedQuery": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithNonZeroStreams": {
+                    "type": "boolean"
+                },
+                "primitivesGeneratedQueryWithRasterizerDiscard": {
                     "type": "boolean"
                 }
             }
@@ -1084,7 +1397,7 @@
                 }
             }
         },
-        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+        "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -1104,6 +1417,18 @@
             "additionalProperties": false,
             "properties": {
                 "rayQuery": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "rayTracingMaintenance1": {
+                    "type": "boolean"
+                },
+                "rayTracingPipelineTraceRaysIndirect2": {
                     "type": "boolean"
                 }
             }
@@ -1318,6 +1643,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderEarlyAndLateFragmentTests": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceShaderFloat16Int8Features": {
             "type": "object",
             "additionalProperties": false,
@@ -1365,6 +1699,15 @@
             "additionalProperties": false,
             "properties": {
                 "shaderIntegerFunctions2": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifier": {
                     "type": "boolean"
                 }
             }
@@ -1429,6 +1772,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "subpassMergeFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
             "type": "object",
             "additionalProperties": false,
@@ -1461,6 +1813,15 @@
             "additionalProperties": false,
             "properties": {
                 "textureCompressionASTC_HDR": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tileProperties": {
                     "type": "boolean"
                 }
             }
@@ -2380,12 +2741,14 @@
                 "VK_SHADER_STAGE_GEOMETRY_BIT",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
                 "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_EXT",
                 "VK_SHADER_STAGE_MESH_BIT_NV",
                 "VK_SHADER_STAGE_MISS_BIT_KHR",
                 "VK_SHADER_STAGE_MISS_BIT_NV",
                 "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
                 "VK_SHADER_STAGE_RAYGEN_BIT_NV",
                 "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_SHADER_STAGE_TASK_BIT_EXT",
                 "VK_SHADER_STAGE_TASK_BIT_NV",
                 "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
                 "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
@@ -2613,6 +2976,7 @@
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS",
                 "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
                 "VK_DRIVER_ID_JUICE_PROPRIETARY",
+                "VK_DRIVER_ID_MESA_DOZEN",
                 "VK_DRIVER_ID_MESA_LLVMPIPE",
                 "VK_DRIVER_ID_MESA_PANVK",
                 "VK_DRIVER_ID_MESA_RADV",
@@ -2670,6 +3034,15 @@
                 },
                 "renderMinor": {
                     "$ref": "#/definitions/int64_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "dynamicPrimitiveTopologyUnrestricted": {
+                    "type": "boolean"
                 }
             }
         },
@@ -2803,6 +3176,15 @@
                 }
             }
         },
+        "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triStripVertexOrderIndependentOfProvokingVertex": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
             "type": "object",
             "additionalProperties": false,
@@ -2869,6 +3251,18 @@
                 }
             }
         },
+        "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "graphicsPipelineLibraryFastLinking": {
+                    "type": "boolean"
+                },
+                "graphicsPipelineLibraryIndependentInterpolationDecoration": {
+                    "type": "boolean"
+                }
+            }
+        },
         "VkPhysicalDeviceIDProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -2902,6 +3296,24 @@
                     },
                     "uniqueItems": false,
                     "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxBlockMatchRegion": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxBoxFilterBlockSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterDimension": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "maxWeightFilterPhases": {
+                    "$ref": "#/definitions/uint32_t"
                 }
             }
         },
@@ -2953,6 +3365,116 @@
             "properties": {
                 "maxBufferSize": {
                     "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndOutputMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxMeshWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPreferredTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadAndSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskPayloadSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskWorkGroupTotalCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "prefersCompactPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersCompactVertexOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationPrimitiveOutput": {
+                    "type": "boolean"
+                },
+                "prefersLocalInvocationVertexOutput": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3041,6 +3563,73 @@
                 }
             }
         },
+        "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxOpacity2StateSubdivisionLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxOpacity4StateSubdivisionLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkOpticalFlowGridSizeFlagBitsNV": {
+            "enum": [
+                "VK_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_NV",
+                "VK_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_NV",
+                "VK_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_NV",
+                "VK_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_NV",
+                "VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV"
+            ]
+        },
+        "VkOpticalFlowGridSizeFlagsNV": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkOpticalFlowGridSizeFlagBitsNV"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceOpticalFlowPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bidirectionalFlowSupported": {
+                    "type": "boolean"
+                },
+                "costSupported": {
+                    "type": "boolean"
+                },
+                "globalFlowSupported": {
+                    "type": "boolean"
+                },
+                "hintSupported": {
+                    "type": "boolean"
+                },
+                "maxHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxNumRegionsOfInterest": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedHintGridSizes": {
+                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
+                },
+                "supportedOutputGridSizes": {
+                    "$ref": "#/definitions/VkOpticalFlowGridSizeFlagsNV"
+                }
+            }
+        },
         "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
             "type": "object",
             "additionalProperties": false,
@@ -3065,6 +3654,40 @@
             "properties": {
                 "allowCommandBufferQueryCopies": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPipelineRobustnessImageBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT"
+            ]
+        },
+        "VkPipelineRobustnessBufferBehaviorEXT": {
+            "enum": [
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT",
+                "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT"
+            ]
+        },
+        "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "defaultRobustnessImages": {
+                    "$ref": "#/definitions/VkPipelineRobustnessImageBehaviorEXT"
+                },
+                "defaultRobustnessStorageBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessUniformBuffers": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
+                },
+                "defaultRobustnessVertexInputs": {
+                    "$ref": "#/definitions/VkPipelineRobustnessBufferBehaviorEXT"
                 }
             }
         },
@@ -3399,6 +4022,20 @@
                 },
                 "integerDotProductAccumulatingSaturating8BitUnsignedAccelerated": {
                     "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderModuleIdentifierAlgorithmUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
                 }
             }
         },
@@ -4021,6 +4658,8 @@
                 "VK_FORMAT_FEATURE_2_BLIT_DST_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                 "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -4036,6 +4675,9 @@
                 "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT",
                 "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV",
+                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV",
+                "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
@@ -4077,7 +4719,9 @@
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                 "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
-                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"
+                "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
+                "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
             ]
         },
         "VkFormatFeatureFlags2": {
@@ -4102,99 +4746,12 @@
                 }
             }
         },
-        "VkVideoDecodeH264PictureLayoutFlagBitsEXT": {
-            "enum": [
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_INTERLEAVED_LINES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT",
-                "VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_EXT"
-            ]
-        },
-        "VkVideoDecodeH264PictureLayoutFlagsEXT": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagBitsEXT"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoDecodeH264ProfileEXT": {
+        "VkSubpassResolvePerformanceQueryEXT": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "pictureLayout": {
-                    "$ref": "#/definitions/VkVideoDecodeH264PictureLayoutFlagsEXT"
-                }
-            }
-        },
-        "VkVideoDecodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH264ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoEncodeH265ProfileEXT": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "VkVideoComponentBitDepthFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR",
-                "VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR"
-            ]
-        },
-        "VkVideoComponentBitDepthFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoComponentBitDepthFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoChromaSubsamplingFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_BIT_KHR",
-                "VK_VIDEO_CHROMA_SUBSAMPLING_MONOCHROME_BIT_KHR"
-            ]
-        },
-        "VkVideoChromaSubsamplingFlagsKHR": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/VkVideoChromaSubsamplingFlagBitsKHR"
-            },
-            "uniqueItems": true
-        },
-        "VkVideoCodecOperationFlagBitsKHR": {
-            "enum": [
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
-                "VK_VIDEO_CODEC_OPERATION_INVALID_BIT_KHR"
-            ]
-        },
-        "VkVideoProfileKHR": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "chromaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "chromaSubsampling": {
-                    "$ref": "#/definitions/VkVideoChromaSubsamplingFlagsKHR"
-                },
-                "lumaBitDepth": {
-                    "$ref": "#/definitions/VkVideoComponentBitDepthFlagsKHR"
-                },
-                "videoCodecOperation": {
-                    "$ref": "#/definitions/VkVideoCodecOperationFlagBitsKHR"
+                "optimal": {
+                    "type": "boolean"
                 }
             }
         },
@@ -4217,20 +4774,8 @@
                 "VkFormatProperties3KHR": {
                     "$ref": "#/definitions/VkFormatProperties3"
                 },
-                "VkVideoDecodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH264ProfileEXT"
-                },
-                "VkVideoDecodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoDecodeH265ProfileEXT"
-                },
-                "VkVideoEncodeH264ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH264ProfileEXT"
-                },
-                "VkVideoEncodeH265ProfileEXT": {
-                    "$ref": "#/definitions/VkVideoEncodeH265ProfileEXT"
-                },
-                "VkVideoProfileKHR": {
-                    "$ref": "#/definitions/VkVideoProfileKHR"
+                "VkSubpassResolvePerformanceQueryEXT": {
+                    "$ref": "#/definitions/VkSubpassResolvePerformanceQueryEXT"
                 }
             }
         },
@@ -4253,6 +4798,7 @@
             "enum": [
                 "VK_QUEUE_COMPUTE_BIT",
                 "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_OPTICAL_FLOW_BIT_NV",
                 "VK_QUEUE_PROTECTED_BIT",
                 "VK_QUEUE_SPARSE_BINDING_BIT",
                 "VK_QUEUE_TRANSFER_BIT",
@@ -4298,6 +4844,7 @@
             "enum": [
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT",
                 "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT",
@@ -4335,9 +4882,12 @@
                 "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT",
                 "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT_KHR",
+                "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_NONE",
                 "VK_PIPELINE_STAGE_2_NONE_KHR",
+                "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT",
                 "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR",
@@ -4346,6 +4896,7 @@
                 "VK_PIPELINE_STAGE_2_RESOLVE_BIT_KHR",
                 "VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV",
                 "VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI",
+                "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT_KHR",
@@ -4401,12 +4952,14 @@
                 "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
                 "VK_PIPELINE_STAGE_HOST_BIT",
                 "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_NONE",
                 "VK_PIPELINE_STAGE_NONE_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR",
                 "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT",
                 "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
                 "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
                 "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
@@ -4462,14 +5015,23 @@
                 }
             }
         },
-        "VkQueueFamilyQueryResultStatusProperties2KHR": {
+        "VkQueueFamilyQueryResultStatusPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "supported": {
+                "queryResultStatusSupport": {
                     "type": "boolean"
                 }
             }
+        },
+        "VkVideoCodecOperationFlagBitsKHR": {
+            "enum": [
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT",
+                "VK_VIDEO_CODEC_OPERATION_NONE_KHR"
+            ]
         },
         "VkVideoCodecOperationFlagsKHR": {
             "type": "array",
@@ -4478,7 +5040,7 @@
             },
             "uniqueItems": true
         },
-        "VkVideoQueueFamilyProperties2KHR": {
+        "VkQueueFamilyVideoPropertiesKHR": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -4546,6 +5108,9 @@
                             "VK_AMD_shader_core_properties2": {
                                 "type": "integer"
                             },
+                            "VK_AMD_shader_early_and_late_fragment_tests": {
+                                "type": "integer"
+                            },
                             "VK_AMD_shader_explicit_vertex_parameter": {
                                 "type": "integer"
                             },
@@ -4582,6 +5147,9 @@
                             "VK_EXT_astc_decode_mode": {
                                 "type": "integer"
                             },
+                            "VK_EXT_attachment_feedback_loop_layout": {
+                                "type": "integer"
+                            },
                             "VK_EXT_blend_operation_advanced": {
                                 "type": "integer"
                             },
@@ -4615,6 +5183,9 @@
                             "VK_EXT_debug_utils": {
                                 "type": "integer"
                             },
+                            "VK_EXT_depth_clamp_zero_one": {
+                                "type": "integer"
+                            },
                             "VK_EXT_depth_clip_control": {
                                 "type": "integer"
                             },
@@ -4625,6 +5196,12 @@
                                 "type": "integer"
                             },
                             "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_address_binding_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_device_fault": {
                                 "type": "integer"
                             },
                             "VK_EXT_device_memory_report": {
@@ -4649,6 +5226,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_extended_dynamic_state2": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_extended_dynamic_state3": {
                                 "type": "integer"
                             },
                             "VK_EXT_external_memory_dma_buf": {
@@ -4678,6 +5258,9 @@
                             "VK_EXT_global_priority_query": {
                                 "type": "integer"
                             },
+                            "VK_EXT_graphics_pipeline_library": {
+                                "type": "integer"
+                            },
                             "VK_EXT_hdr_metadata": {
                                 "type": "integer"
                             },
@@ -4685,6 +5268,15 @@
                                 "type": "integer"
                             },
                             "VK_EXT_host_query_reset": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_2d_view_of_3d": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_compression_control_swapchain": {
                                 "type": "integer"
                             },
                             "VK_EXT_image_drm_format_modifier": {
@@ -4702,6 +5294,9 @@
                             "VK_EXT_inline_uniform_block": {
                                 "type": "integer"
                             },
+                            "VK_EXT_legacy_dithering": {
+                                "type": "integer"
+                            },
                             "VK_EXT_line_rasterization": {
                                 "type": "integer"
                             },
@@ -4714,10 +5309,28 @@
                             "VK_EXT_memory_priority": {
                                 "type": "integer"
                             },
+                            "VK_EXT_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_metal_objects": {
+                                "type": "integer"
+                            },
                             "VK_EXT_metal_surface": {
                                 "type": "integer"
                             },
                             "VK_EXT_multi_draw": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_multisampled_render_to_single_sampled": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_mutable_descriptor_type": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_non_seamless_cube_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_opacity_micromap": {
                                 "type": "integer"
                             },
                             "VK_EXT_pageable_device_local_memory": {
@@ -4735,10 +5348,22 @@
                             "VK_EXT_pipeline_creation_feedback": {
                                 "type": "integer"
                             },
+                            "VK_EXT_pipeline_properties": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_protected_access": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pipeline_robustness": {
+                                "type": "integer"
+                            },
                             "VK_EXT_post_depth_coverage": {
                                 "type": "integer"
                             },
                             "VK_EXT_primitive_topology_list_restart": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_primitives_generated_query": {
                                 "type": "integer"
                             },
                             "VK_EXT_private_data": {
@@ -4748,6 +5373,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_rasterization_order_attachment_access": {
                                 "type": "integer"
                             },
                             "VK_EXT_rgba10x6_formats": {
@@ -4780,6 +5408,9 @@
                             "VK_EXT_shader_image_atomic_int64": {
                                 "type": "integer"
                             },
+                            "VK_EXT_shader_module_identifier": {
+                                "type": "integer"
+                            },
                             "VK_EXT_shader_stencil_export": {
                                 "type": "integer"
                             },
@@ -4793,6 +5424,9 @@
                                 "type": "integer"
                             },
                             "VK_EXT_subgroup_size_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_subpass_merge_feedback": {
                                 "type": "integer"
                             },
                             "VK_EXT_swapchain_colorspace": {
@@ -4990,6 +5624,9 @@
                             "VK_KHR_format_feature_flags2": {
                                 "type": "integer"
                             },
+                            "VK_KHR_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
                             "VK_KHR_fragment_shading_rate": {
                                 "type": "integer"
                             },
@@ -5057,6 +5694,9 @@
                                 "type": "integer"
                             },
                             "VK_KHR_ray_query": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_ray_tracing_maintenance1": {
                                 "type": "integer"
                             },
                             "VK_KHR_ray_tracing_pipeline": {
@@ -5263,6 +5903,12 @@
                             "VK_NV_mesh_shader": {
                                 "type": "integer"
                             },
+                            "VK_NV_optical_flow": {
+                                "type": "integer"
+                            },
+                            "VK_NV_present_barrier": {
+                                "type": "integer"
+                            },
                             "VK_NV_ray_tracing": {
                                 "type": "integer"
                             },
@@ -5302,6 +5948,9 @@
                             "VK_QCOM_fragment_density_map_offset": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_image_processing": {
+                                "type": "integer"
+                            },
                             "VK_QCOM_render_pass_shader_resolve": {
                                 "type": "integer"
                             },
@@ -5314,7 +5963,13 @@
                             "VK_QCOM_rotated_copy_commands": {
                                 "type": "integer"
                             },
+                            "VK_QCOM_tile_properties": {
+                                "type": "integer"
+                            },
                             "VK_QNX_screen_surface": {
+                                "type": "integer"
+                            },
+                            "VK_SEC_amigo_profiling": {
                                 "type": "integer"
                             },
                             "VK_VALVE_descriptor_set_host_mapping": {
@@ -5359,6 +6014,15 @@
                             },
                             "VkPhysicalDeviceAccelerationStructureFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceAccelerationStructureFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceAddressBindingReportFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAddressBindingReportFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceAmigoProfilingFeaturesSEC": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAmigoProfilingFeaturesSEC"
+                            },
+                            "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"
                             },
                             "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
@@ -5405,6 +6069,9 @@
                             "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"
                             },
+                            "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthClampZeroOneFeaturesEXT"
+                            },
                             "VkPhysicalDeviceDepthClipControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDepthClipControlFeaturesEXT"
                             },
@@ -5441,11 +6108,17 @@
                             "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState2FeaturesEXT"
                             },
+                            "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"
+                            },
                             "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicStateFeaturesEXT"
                             },
                             "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryRDMAFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFaultFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFaultFeaturesEXT"
                             },
                             "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMap2FeaturesEXT"
@@ -5456,8 +6129,11 @@
                             "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
-                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR"
                             },
                             "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"
@@ -5474,11 +6150,26 @@
                             "VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT"
+                            },
                             "VkPhysicalDeviceHostQueryResetFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
                             },
                             "VkPhysicalDeviceHostQueryResetFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceHostQueryResetFeatures"
+                            },
+                            "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceImageProcessingFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingFeaturesQCOM"
                             },
                             "VkPhysicalDeviceImageRobustnessFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceImageRobustnessFeatures"
@@ -5510,6 +6201,9 @@
                             "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInvocationMaskFeaturesHUAWEI"
                             },
+                            "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceLegacyDitheringFeaturesEXT"
+                            },
                             "VkPhysicalDeviceLineRasterizationFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceLineRasterizationFeaturesEXT"
                             },
@@ -5525,11 +6219,17 @@
                             "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
                             },
+                            "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
                             },
                             "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiDrawFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT"
                             },
                             "VkPhysicalDeviceMultiviewFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
@@ -5537,8 +6237,20 @@
                             "VkPhysicalDeviceMultiviewFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
                             },
+                            "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
                             "VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE": {
-                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE"
+                                "$ref": "#/definitions/VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceOpacityMicromapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceOpticalFlowFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowFeaturesNV"
                             },
                             "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT"
@@ -5555,8 +6267,20 @@
                             "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR"
                             },
+                            "VkPhysicalDevicePipelinePropertiesFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelinePropertiesFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineProtectedAccessFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessFeaturesEXT"
+                            },
                             "VkPhysicalDevicePortabilitySubsetFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePortabilitySubsetFeaturesKHR"
+                            },
+                            "VkPhysicalDevicePresentBarrierFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDevicePresentBarrierFeaturesNV"
                             },
                             "VkPhysicalDevicePresentIdFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePresentIdFeaturesKHR"
@@ -5566,6 +6290,9 @@
                             },
                             "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT"
+                            },
+                            "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT"
                             },
                             "VkPhysicalDevicePrivateDataFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDevicePrivateDataFeatures"
@@ -5582,11 +6309,17 @@
                             "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"
                             },
+                            "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
+                            },
                             "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
-                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM"
+                                "$ref": "#/definitions/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT"
                             },
                             "VkPhysicalDeviceRayQueryFeaturesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayQueryFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"
                             },
                             "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceRayTracingMotionBlurFeaturesNV"
@@ -5645,6 +6378,9 @@
                             "VkPhysicalDeviceShaderDrawParameterFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParametersFeatures"
                             },
+                            "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD"
+                            },
                             "VkPhysicalDeviceShaderFloat16Int8Features": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderFloat16Int8Features"
                             },
@@ -5668,6 +6404,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"
@@ -5696,6 +6435,9 @@
                             "VkPhysicalDeviceSubgroupSizeControlFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubgroupSizeControlFeatures"
                             },
+                            "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT"
+                            },
                             "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI": {
                                 "$ref": "#/definitions/VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"
                             },
@@ -5713,6 +6455,9 @@
                             },
                             "VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTextureCompressionASTCHDRFeatures"
+                            },
+                            "VkPhysicalDeviceTilePropertiesFeaturesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTilePropertiesFeaturesQCOM"
                             },
                             "VkPhysicalDeviceTimelineSemaphoreFeatures": {
                                 "$ref": "#/definitions/VkPhysicalDeviceTimelineSemaphoreFeatures"
@@ -5835,6 +6580,9 @@
                             "VkPhysicalDeviceDrmPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceDrmPropertiesEXT"
                             },
+                            "VkPhysicalDeviceExtendedDynamicState3PropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"
+                            },
                             "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
                             },
@@ -5853,17 +6601,26 @@
                             "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
                             },
+                            "VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"
+                            },
                             "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV"
                             },
                             "VkPhysicalDeviceFragmentShadingRatePropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceFragmentShadingRatePropertiesKHR"
                             },
+                            "VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT"
+                            },
                             "VkPhysicalDeviceIDProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
                             },
                             "VkPhysicalDeviceIDPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceImageProcessingPropertiesQCOM": {
+                                "$ref": "#/definitions/VkPhysicalDeviceImageProcessingPropertiesQCOM"
                             },
                             "VkPhysicalDeviceInlineUniformBlockProperties": {
                                 "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockProperties"
@@ -5886,6 +6643,9 @@
                             "VkPhysicalDeviceMaintenance4PropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMaintenance4Properties"
                             },
+                            "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesEXT"
+                            },
                             "VkPhysicalDeviceMeshShaderPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
                             },
@@ -5901,11 +6661,20 @@
                             "VkPhysicalDeviceMultiviewPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
                             },
+                            "VkPhysicalDeviceOpacityMicromapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceOpacityMicromapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceOpticalFlowPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceOpticalFlowPropertiesNV"
+                            },
                             "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
                                 "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
                             },
                             "VkPhysicalDevicePerformanceQueryPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDevicePerformanceQueryPropertiesKHR"
+                            },
+                            "VkPhysicalDevicePipelineRobustnessPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePipelineRobustnessPropertiesEXT"
                             },
                             "VkPhysicalDevicePointClippingProperties": {
                                 "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
@@ -5954,6 +6723,9 @@
                             },
                             "VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderIntegerDotProductProperties"
+                            },
+                            "VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT"
                             },
                             "VkPhysicalDeviceShaderSMBuiltinsPropertiesNV": {
                                 "$ref": "#/definitions/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV"
@@ -6691,6 +7463,9 @@
                             "VK_FORMAT_R16G16B16_USCALED": {
                                 "$ref": "#/definitions/formatProperties"
                             },
+                            "VK_FORMAT_R16G16_S10_5_NV": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
                             "VK_FORMAT_R16G16_SFLOAT": {
                                 "$ref": "#/definitions/formatProperties"
                             },
@@ -6940,11 +7715,11 @@
                                 "VkQueueFamilyGlobalPriorityPropertiesEXT": {
                                     "$ref": "#/definitions/VkQueueFamilyGlobalPriorityPropertiesKHR"
                                 },
-                                "VkQueueFamilyQueryResultStatusProperties2KHR": {
-                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusProperties2KHR"
+                                "VkQueueFamilyQueryResultStatusPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyQueryResultStatusPropertiesKHR"
                                 },
-                                "VkVideoQueueFamilyProperties2KHR": {
-                                    "$ref": "#/definitions/VkVideoQueueFamilyProperties2KHR"
+                                "VkQueueFamilyVideoPropertiesKHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyVideoPropertiesKHR"
                                 }
                             }
                         }
@@ -7029,11 +7804,41 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {
-                                "type": "string"
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optional capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "fallback": {

--- a/vulkan/profiles-0.8.1-96.json
+++ b/vulkan/profiles-0.8.1-96.json
@@ -1,0 +1,3590 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-96.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.96",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-96.json
+++ b/vulkan/profiles-0.8.1-96.json
@@ -3555,7 +3555,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-97.json
+++ b/vulkan/profiles-0.8.1-97.json
@@ -3637,7 +3637,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-97.json
+++ b/vulkan/profiles-0.8.1-97.json
@@ -1,0 +1,3672 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-97.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.97",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-98.json
+++ b/vulkan/profiles-0.8.1-98.json
@@ -3637,7 +3637,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-98.json
+++ b/vulkan/profiles-0.8.1-98.json
@@ -1,0 +1,3672 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-98.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.98",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vulkan/profiles-0.8.1-99.json
+++ b/vulkan/profiles-0.8.1-99.json
@@ -3637,7 +3637,26 @@
                             }
                         },
                         "capabilities": {
-                            "description": "The list of capability sets that can be reference by a profile.",
+                            "description": "The list of required capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "optionals": {
+                            "description": "The list of optioanl capability sets that can be reference by a profile.",
                             "type": "array",
                             "uniqueItems": true,
                             "items": {

--- a/vulkan/profiles-0.8.1-99.json
+++ b/vulkan/profiles-0.8.1-99.json
@@ -1,0 +1,3672 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schema.khronos.org/vulkan/profiles-0.8.1-99.json#",
+    "title": "Vulkan Profiles Schema for Vulkan 1.1.99",
+    "additionalProperties": true,
+    "required": [
+        "capabilities",
+        "profiles"
+    ],
+    "definitions": {
+        "status": {
+            "description": "The development status of the setting. When missing, this property is inherited from parent nodes. If no parent node defines it, the default value is 'STABLE'.",
+            "type": "string",
+            "enum": [
+                "ALPHA",
+                "BETA",
+                "STABLE",
+                "DEPRECATED"
+            ]
+        },
+        "contributor": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "company"
+            ],
+            "properties": {
+                "company": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_.]+@[a-zA-Z0-9-].[a-zA-Z0-9-.]+$"
+                },
+                "github": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9_-]+$"
+                },
+                "contact": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "uint8_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
+        "int32_t": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "uint32_t": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 4294967295
+        },
+        "int64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "uint64_t": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "VkDeviceSize": {
+            "$ref": "#/definitions/uint64_t"
+        },
+        "char": {
+            "type": "string"
+        },
+        "float": {
+            "type": "number"
+        },
+        "size_t": {
+            "$ref": "#/definitions/uint32_t"
+        },
+        "VkPhysicalDeviceFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "alphaToOne": {
+                    "type": "boolean"
+                },
+                "depthBiasClamp": {
+                    "type": "boolean"
+                },
+                "depthBounds": {
+                    "type": "boolean"
+                },
+                "depthClamp": {
+                    "type": "boolean"
+                },
+                "drawIndirectFirstInstance": {
+                    "type": "boolean"
+                },
+                "dualSrcBlend": {
+                    "type": "boolean"
+                },
+                "fillModeNonSolid": {
+                    "type": "boolean"
+                },
+                "fragmentStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "fullDrawIndexUint32": {
+                    "type": "boolean"
+                },
+                "geometryShader": {
+                    "type": "boolean"
+                },
+                "imageCubeArray": {
+                    "type": "boolean"
+                },
+                "independentBlend": {
+                    "type": "boolean"
+                },
+                "inheritedQueries": {
+                    "type": "boolean"
+                },
+                "largePoints": {
+                    "type": "boolean"
+                },
+                "logicOp": {
+                    "type": "boolean"
+                },
+                "multiDrawIndirect": {
+                    "type": "boolean"
+                },
+                "multiViewport": {
+                    "type": "boolean"
+                },
+                "occlusionQueryPrecise": {
+                    "type": "boolean"
+                },
+                "pipelineStatisticsQuery": {
+                    "type": "boolean"
+                },
+                "robustBufferAccess": {
+                    "type": "boolean"
+                },
+                "sampleRateShading": {
+                    "type": "boolean"
+                },
+                "samplerAnisotropy": {
+                    "type": "boolean"
+                },
+                "shaderClipDistance": {
+                    "type": "boolean"
+                },
+                "shaderCullDistance": {
+                    "type": "boolean"
+                },
+                "shaderFloat64": {
+                    "type": "boolean"
+                },
+                "shaderImageGatherExtended": {
+                    "type": "boolean"
+                },
+                "shaderInt16": {
+                    "type": "boolean"
+                },
+                "shaderInt64": {
+                    "type": "boolean"
+                },
+                "shaderResourceMinLod": {
+                    "type": "boolean"
+                },
+                "shaderResourceResidency": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageExtendedFormats": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageMultisample": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageReadWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageWriteWithoutFormat": {
+                    "type": "boolean"
+                },
+                "shaderTessellationAndGeometryPointSize": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "sparseBinding": {
+                    "type": "boolean"
+                },
+                "sparseResidency16Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency2Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency4Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidency8Samples": {
+                    "type": "boolean"
+                },
+                "sparseResidencyAliased": {
+                    "type": "boolean"
+                },
+                "sparseResidencyBuffer": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage2D": {
+                    "type": "boolean"
+                },
+                "sparseResidencyImage3D": {
+                    "type": "boolean"
+                },
+                "tessellationShader": {
+                    "type": "boolean"
+                },
+                "textureCompressionASTC_LDR": {
+                    "type": "boolean"
+                },
+                "textureCompressionBC": {
+                    "type": "boolean"
+                },
+                "textureCompressionETC2": {
+                    "type": "boolean"
+                },
+                "variableMultisampleRate": {
+                    "type": "boolean"
+                },
+                "vertexPipelineStoresAndAtomics": {
+                    "type": "boolean"
+                },
+                "wideLines": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFeatures2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "features": {
+                    "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                }
+            }
+        },
+        "VkPhysicalDevice16BitStorageFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer16BitAccess": {
+                    "type": "boolean"
+                },
+                "storageInputOutput16": {
+                    "type": "boolean"
+                },
+                "storagePushConstant16": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer16BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevice8BitStorageFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "storageBuffer8BitAccess": {
+                    "type": "boolean"
+                },
+                "storagePushConstant8": {
+                    "type": "boolean"
+                },
+                "uniformAndStorageBuffer8BitAccess": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "decodeModeSharedExponent": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendCoherentOperations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferDeviceAddress": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressCaptureReplay": {
+                    "type": "boolean"
+                },
+                "bufferDeviceAddressMultiDevice": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeDerivativeGroupLinear": {
+                    "type": "boolean"
+                },
+                "computeDerivativeGroupQuads": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conditionalRendering": {
+                    "type": "boolean"
+                },
+                "inheritedConditionalRendering": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cornerSampledImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingPartiallyBound": {
+                    "type": "boolean"
+                },
+                "descriptorBindingSampledImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageImageUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingStorageTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUniformTexelBufferUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "descriptorBindingUpdateUnusedWhilePending": {
+                    "type": "boolean"
+                },
+                "descriptorBindingVariableDescriptorCount": {
+                    "type": "boolean"
+                },
+                "runtimeDescriptorArray": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderStorageTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayDynamicIndexing": {
+                    "type": "boolean"
+                },
+                "shaderUniformTexelBufferArrayNonUniformIndexing": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclusiveScissor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderFloat16": {
+                    "type": "boolean"
+                },
+                "shaderInt8": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityMap": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapDynamic": {
+                    "type": "boolean"
+                },
+                "fragmentDensityMapNonSubsampledImages": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentShaderBarycentric": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "descriptorBindingInlineUniformBlockUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "inlineUniformBlock": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "memoryPriority": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "meshShader": {
+                    "type": "boolean"
+                },
+                "taskShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "multiview": {
+                    "type": "boolean"
+                },
+                "multiviewGeometryShader": {
+                    "type": "boolean"
+                },
+                "multiviewTessellationShader": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedMemory": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "representativeFragmentTest": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "samplerYcbcrConversion": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "scalarBlockLayout": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderBufferInt64Atomics": {
+                    "type": "boolean"
+                },
+                "shaderSharedInt64Atomics": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderDrawParameterFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shaderDrawParameters": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "imageFootprint": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateCoarseSampleOrder": {
+                    "type": "boolean"
+                },
+                "shadingRateImage": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "geometryStreams": {
+                    "type": "boolean"
+                },
+                "transformFeedback": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVariablePointerFeatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "variablePointers": {
+                    "type": "boolean"
+                },
+                "variablePointersStorageBuffer": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vertexAttributeInstanceRateDivisor": {
+                    "type": "boolean"
+                },
+                "vertexAttributeInstanceRateZeroDivisor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "vulkanMemoryModel": {
+                    "type": "boolean"
+                },
+                "vulkanMemoryModelDeviceScope": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceType": {
+            "enum": [
+                "VK_PHYSICAL_DEVICE_TYPE_CPU",
+                "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU",
+                "VK_PHYSICAL_DEVICE_TYPE_OTHER",
+                "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
+            ]
+        },
+        "VkSampleCountFlagBits": {
+            "enum": [
+                "VK_SAMPLE_COUNT_16_BIT",
+                "VK_SAMPLE_COUNT_1_BIT",
+                "VK_SAMPLE_COUNT_2_BIT",
+                "VK_SAMPLE_COUNT_32_BIT",
+                "VK_SAMPLE_COUNT_4_BIT",
+                "VK_SAMPLE_COUNT_64_BIT",
+                "VK_SAMPLE_COUNT_8_BIT"
+            ]
+        },
+        "VkSampleCountFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSampleCountFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceLimits": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferImageGranularity": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "discreteQueuePriorities": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "framebufferColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferNoAttachmentsSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "framebufferStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "lineWidthGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "lineWidthRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxBoundDescriptorSets": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxClipDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxCombinedClipAndCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeSharedMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupCount": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxComputeWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxComputeWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxCullDistances": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndexedIndexValue": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDrawIndirectCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentCombinedOutputResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentDualSrcAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFragmentOutputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferHeight": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxFramebufferWidth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryShaderInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageArrayLayers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension1D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension2D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimension3D": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxImageDimensionCube": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxMemoryAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPushConstantsSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSampleMaskWords": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAllocationCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSamplerAnisotropy": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxSamplerLodBias": {
+                    "$ref": "#/definitions/float"
+                },
+                "maxStorageBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerPatchOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlPerVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationControlTotalOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationInputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationEvaluationOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationGenerationLevel": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTessellationPatchSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelBufferElements": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelGatherOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTexelOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUniformBufferRange": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributeOffset": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputAttributes": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindingStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexInputBindings": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVertexOutputComponents": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxViewportDimensions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "maxViewports": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minInterpolationOffset": {
+                    "$ref": "#/definitions/float"
+                },
+                "minMemoryMapAlignment": {
+                    "$ref": "#/definitions/size_t"
+                },
+                "minStorageBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "minTexelGatherOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minTexelOffset": {
+                    "$ref": "#/definitions/int32_t"
+                },
+                "minUniformBufferOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "mipmapPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "nonCoherentAtomSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyOffsetAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "optimalBufferCopyRowPitchAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "pointSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "pointSizeRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampledImageColorSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageDepthSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageIntegerSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampledImageStencilSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sparseAddressSpaceSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "standardSampleLocations": {
+                    "type": "boolean"
+                },
+                "storageImageSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "strictLines": {
+                    "type": "boolean"
+                },
+                "subPixelInterpolationOffsetBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subPixelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "subTexelPrecisionBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "timestampComputeAndGraphics": {
+                    "type": "boolean"
+                },
+                "timestampPeriod": {
+                    "$ref": "#/definitions/float"
+                },
+                "viewportBoundsRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "viewportSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSparseProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "residencyAlignedMipSize": {
+                    "type": "boolean"
+                },
+                "residencyNonResidentStrict": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard2DMultisampleBlockShape": {
+                    "type": "boolean"
+                },
+                "residencyStandard3DBlockShape": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "apiVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceID": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceName": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "deviceType": {
+                    "$ref": "#/definitions/VkPhysicalDeviceType"
+                },
+                "driverVersion": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "limits": {
+                    "$ref": "#/definitions/VkPhysicalDeviceLimits"
+                },
+                "pipelineCacheUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "sparseProperties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceSparseProperties"
+                },
+                "vendorID": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "properties": {
+                    "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                }
+            }
+        },
+        "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "advancedBlendAllOperations": {
+                    "type": "boolean"
+                },
+                "advancedBlendCorrelatedOverlap": {
+                    "type": "boolean"
+                },
+                "advancedBlendIndependentBlend": {
+                    "type": "boolean"
+                },
+                "advancedBlendMaxColorAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "advancedBlendNonPremultipliedDstColor": {
+                    "type": "boolean"
+                },
+                "advancedBlendNonPremultipliedSrcColor": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conservativePointAndLineRasterization": {
+                    "type": "boolean"
+                },
+                "conservativeRasterizationPostDepthCoverage": {
+                    "type": "boolean"
+                },
+                "degenerateLinesRasterized": {
+                    "type": "boolean"
+                },
+                "degenerateTrianglesRasterized": {
+                    "type": "boolean"
+                },
+                "extraPrimitiveOverestimationSizeGranularity": {
+                    "$ref": "#/definitions/float"
+                },
+                "fullyCoveredFragmentShaderInputVariable": {
+                    "type": "boolean"
+                },
+                "maxExtraPrimitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveOverestimationSize": {
+                    "$ref": "#/definitions/float"
+                },
+                "primitiveUnderestimation": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkResolveModeFlagBitsKHR": {
+            "enum": [
+                "VK_RESOLVE_MODE_AVERAGE_BIT_KHR",
+                "VK_RESOLVE_MODE_MAX_BIT_KHR",
+                "VK_RESOLVE_MODE_MIN_BIT_KHR",
+                "VK_RESOLVE_MODE_NONE_KHR",
+                "VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR"
+            ]
+        },
+        "VkResolveModeFlagsKHR": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkResolveModeFlagBitsKHR"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "independentResolve": {
+                    "type": "boolean"
+                },
+                "independentResolveNone": {
+                    "type": "boolean"
+                },
+                "supportedDepthResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                },
+                "supportedStencilResolveModes": {
+                    "$ref": "#/definitions/VkResolveModeFlagsKHR"
+                }
+            }
+        },
+        "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInputAttachments": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSampledImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindSamplers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindStorageImages": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindUniformBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageUpdateAfterBindResources": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxUpdateAfterBindDescriptorsInAllPools": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "quadDivergentImplicitLod": {
+                    "type": "boolean"
+                },
+                "robustBufferAccessUpdateAfterBind": {
+                    "type": "boolean"
+                },
+                "shaderInputAttachmentArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderSampledImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderStorageImageArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                },
+                "shaderUniformBufferArrayNonUniformIndexingNative": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDiscardRectangles": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkConformanceVersionKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "major": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "minor": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "patch": {
+                    "$ref": "#/definitions/uint8_t"
+                },
+                "subminor": {
+                    "$ref": "#/definitions/uint8_t"
+                }
+            }
+        },
+        "VkDriverIdKHR": {
+            "enum": [
+                "VK_DRIVER_ID_AMD_OPEN_SOURCE_KHR",
+                "VK_DRIVER_ID_AMD_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_ARM_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_GOOGLE_PASTEL_KHR",
+                "VK_DRIVER_ID_IMAGINATION_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR",
+                "VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS_KHR",
+                "VK_DRIVER_ID_MESA_RADV_KHR",
+                "VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR",
+                "VK_DRIVER_ID_QUALCOMM_PROPRIETARY_KHR"
+            ]
+        },
+        "VkPhysicalDeviceDriverPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "conformanceVersion": {
+                    "$ref": "#/definitions/VkConformanceVersionKHR"
+                },
+                "driverID": {
+                    "$ref": "#/definitions/VkDriverIdKHR"
+                },
+                "driverInfo": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "driverName": {
+                    "type": "string",
+                    "maxLength": 255
+                }
+            }
+        },
+        "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImportedHostPointerAlignment": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                }
+            }
+        },
+        "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "separateDenormSettings": {
+                    "type": "boolean"
+                },
+                "separateRoundingModeSettings": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormFlushToZeroFloat64": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderDenormPreserveFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTEFloat64": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat16": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat32": {
+                    "type": "boolean"
+                },
+                "shaderRoundingModeRTZFloat64": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat16": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat32": {
+                    "type": "boolean"
+                },
+                "shaderSignedZeroInfNanPreserveFloat64": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkExtent2D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "fragmentDensityInvocations": {
+                    "type": "boolean"
+                },
+                "maxFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "minFragmentDensityTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkPhysicalDeviceIDProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deviceLUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 8
+                },
+                "deviceLUIDValid": {
+                    "type": "boolean"
+                },
+                "deviceNodeMask": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "deviceUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                },
+                "driverUUID": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint8_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 16
+                }
+            }
+        },
+        "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxInlineUniformBlockSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMaintenance3Properties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMemoryAllocationSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxPerSetDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMeshShaderPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDrawMeshTasksCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputPrimitives": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshOutputVertices": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMeshWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "maxTaskOutputCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskTotalMemorySize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupInvocations": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTaskWorkGroupSize": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32_t"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 3
+                },
+                "meshOutputPerPrimitiveGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "meshOutputPerVertexGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "perViewPositionAllComponents": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceMultiviewProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxMultiviewInstanceIndex": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxMultiviewViewCount": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pciBus": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDevice": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciDomain": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "pciFunction": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPointClippingBehavior": {
+            "enum": [
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES",
+                "VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES_KHR",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY",
+                "VK_POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY_KHR"
+            ]
+        },
+        "VkPhysicalDevicePointClippingProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pointClippingBehavior": {
+                    "$ref": "#/definitions/VkPointClippingBehavior"
+                }
+            }
+        },
+        "VkPhysicalDeviceProtectedMemoryProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protectedNoFault": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxPushDescriptors": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceRayTracingPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxDescriptorSetAccelerationStructures": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxGeometryCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxInstanceCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "maxRecursionDepth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxShaderGroupStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTriangleCount": {
+                    "$ref": "#/definitions/uint64_t"
+                },
+                "shaderGroupBaseAlignment": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderGroupHandleSize": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxSampleLocationGridSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                },
+                "sampleLocationCoordinateRange": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/float"
+                    },
+                    "uniqueItems": false,
+                    "maxItems": 2
+                },
+                "sampleLocationSampleCounts": {
+                    "$ref": "#/definitions/VkSampleCountFlags"
+                },
+                "sampleLocationSubPixelBits": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "variableSampleLocations": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "filterMinmaxImageComponentMapping": {
+                    "type": "boolean"
+                },
+                "filterMinmaxSingleComponentFormats": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceShaderCorePropertiesAMD": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "computeUnitsPerShaderArray": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minSgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "minVgprAllocation": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "sgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderArraysPerEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shaderEngineCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "simdPerComputeUnit": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprAllocationGranularity": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "vgprsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "wavefrontsPerSimd": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "shadingRateMaxCoarseSamples": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRatePaletteSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "shadingRateTexelSize": {
+                    "$ref": "#/definitions/VkExtent2D"
+                }
+            }
+        },
+        "VkSubgroupFeatureFlagBits": {
+            "enum": [
+                "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV",
+                "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                "VK_SUBGROUP_FEATURE_VOTE_BIT"
+            ]
+        },
+        "VkSubgroupFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkSubgroupFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkShaderStageFlagBits": {
+            "enum": [
+                "VK_SHADER_STAGE_ALL",
+                "VK_SHADER_STAGE_ALL_GRAPHICS",
+                "VK_SHADER_STAGE_ANY_HIT_BIT_NV",
+                "VK_SHADER_STAGE_CALLABLE_BIT_NV",
+                "VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV",
+                "VK_SHADER_STAGE_COMPUTE_BIT",
+                "VK_SHADER_STAGE_FRAGMENT_BIT",
+                "VK_SHADER_STAGE_GEOMETRY_BIT",
+                "VK_SHADER_STAGE_INTERSECTION_BIT_NV",
+                "VK_SHADER_STAGE_MESH_BIT_NV",
+                "VK_SHADER_STAGE_MISS_BIT_NV",
+                "VK_SHADER_STAGE_RAYGEN_BIT_NV",
+                "VK_SHADER_STAGE_TASK_BIT_NV",
+                "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                "VK_SHADER_STAGE_VERTEX_BIT"
+            ]
+        },
+        "VkShaderStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkShaderStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkPhysicalDeviceSubgroupProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quadOperationsInAllStages": {
+                    "type": "boolean"
+                },
+                "subgroupSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "supportedOperations": {
+                    "$ref": "#/definitions/VkSubgroupFeatureFlags"
+                },
+                "supportedStages": {
+                    "$ref": "#/definitions/VkShaderStageFlags"
+                }
+            }
+        },
+        "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxTransformFeedbackBufferDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferDataStride": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackBufferSize": {
+                    "$ref": "#/definitions/VkDeviceSize"
+                },
+                "maxTransformFeedbackBuffers": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreamDataSize": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "maxTransformFeedbackStreams": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "transformFeedbackDraw": {
+                    "type": "boolean"
+                },
+                "transformFeedbackQueries": {
+                    "type": "boolean"
+                },
+                "transformFeedbackRasterizationStreamSelect": {
+                    "type": "boolean"
+                },
+                "transformFeedbackStreamsLinesTriangles": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maxVertexAttribDivisor": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkFormatFeatureFlagBits": {
+            "enum": [
+                "VK_FORMAT_FEATURE_BLIT_DST_BIT",
+                "VK_FORMAT_FEATURE_BLIT_SRC_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT",
+                "VK_FORMAT_FEATURE_DISJOINT_BIT_KHR",
+                "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT",
+                "VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT_EXT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT",
+                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT",
+                "VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR",
+                "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT",
+                "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
+            ]
+        },
+        "VkFormatFeatureFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkFormatFeatureFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkFormatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bufferFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "linearTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                },
+                "optimalTilingFeatures": {
+                    "$ref": "#/definitions/VkFormatFeatureFlags"
+                }
+            }
+        },
+        "VkFormatProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "formatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                }
+            }
+        },
+        "formatProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "VkFormatProperties": {
+                    "$ref": "#/definitions/VkFormatProperties"
+                },
+                "VkFormatProperties2": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                },
+                "VkFormatProperties2KHR": {
+                    "$ref": "#/definitions/VkFormatProperties2"
+                }
+            }
+        },
+        "VkExtent3D": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "depth": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "height": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "width": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFlagBits": {
+            "enum": [
+                "VK_QUEUE_COMPUTE_BIT",
+                "VK_QUEUE_GRAPHICS_BIT",
+                "VK_QUEUE_PROTECTED_BIT",
+                "VK_QUEUE_SPARSE_BINDING_BIT",
+                "VK_QUEUE_TRANSFER_BIT"
+            ]
+        },
+        "VkQueueFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkQueueFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "minImageTransferGranularity": {
+                    "$ref": "#/definitions/VkExtent3D"
+                },
+                "queueCount": {
+                    "$ref": "#/definitions/uint32_t"
+                },
+                "queueFlags": {
+                    "$ref": "#/definitions/VkQueueFlags"
+                },
+                "timestampValidBits": {
+                    "$ref": "#/definitions/uint32_t"
+                }
+            }
+        },
+        "VkQueueFamilyProperties2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "queueFamilyProperties": {
+                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                }
+            }
+        },
+        "VkPipelineStageFlagBits": {
+            "enum": [
+                "VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_NV",
+                "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT",
+                "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT",
+                "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT",
+                "VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX",
+                "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT",
+                "VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT",
+                "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT",
+                "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT",
+                "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT",
+                "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT",
+                "VK_PIPELINE_STAGE_HOST_BIT",
+                "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT",
+                "VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV",
+                "VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV",
+                "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT",
+                "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT",
+                "VK_PIPELINE_STAGE_TRANSFER_BIT",
+                "VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT",
+                "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT",
+                "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
+            ]
+        },
+        "VkPipelineStageFlags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/VkPipelineStageFlagBits"
+            },
+            "uniqueItems": true
+        },
+        "VkQueueFamilyCheckpointPropertiesNV": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "checkpointExecutionStageMask": {
+                    "$ref": "#/definitions/VkPipelineStageFlags"
+                }
+            }
+        }
+    },
+    "properties": {
+        "capabilities": {
+            "description": "The block that specifies the list of capabilities sets.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "extensions": {
+                        "description": "The block that stores required extensions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_AMD_buffer_marker": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gcn_shader": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_half_float": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_gpu_shader_int16": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_memory_overallocation_behavior": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_mixed_attachment_samples": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_negative_viewport_height": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_rasterization_order": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_core_properties": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_explicit_vertex_parameter": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_fragment_mask": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_image_load_store_lod": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_info": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_shader_trinary_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_AMD_texture_gather_bias_lod": {
+                                "type": "integer"
+                            },
+                            "VK_ANDROID_external_memory_android_hardware_buffer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_acquire_xlib_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_astc_decode_mode": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_blend_operation_advanced": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_buffer_device_address": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_calibrated_timestamps": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conditional_rendering": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_conservative_rasterization": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_marker": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_report": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_debug_utils": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_depth_range_unrestricted": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_descriptor_indexing": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_direct_mode_display": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_discard_rectangles": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_control": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_display_surface_counter": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_dma_buf": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_external_memory_host": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_fragment_density_map": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_global_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_hdr_metadata": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_image_drm_format_modifier": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_inline_uniform_block": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_budget": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_memory_priority": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_pci_bus_info": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_post_depth_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_queue_family_foreign": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sample_locations": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_sampler_filter_minmax": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_scalar_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_separate_stencil_usage": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_stencil_export": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_ballot": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_subgroup_vote": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_shader_viewport_index_layer": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_swapchain_colorspace": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_transform_feedback": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_cache": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_features": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_validation_flags": {
+                                "type": "integer"
+                            },
+                            "VK_EXT_vertex_attribute_divisor": {
+                                "type": "integer"
+                            },
+                            "VK_FUCHSIA_imagepipe_surface": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_decorate_string": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_display_timing": {
+                                "type": "integer"
+                            },
+                            "VK_GOOGLE_hlsl_functionality1": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_filter_cubic": {
+                                "type": "integer"
+                            },
+                            "VK_IMG_format_pvrtc": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_16bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_8bit_storage": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_android_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_bind_memory2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_create_renderpass2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_depth_stencil_resolve": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_descriptor_update_template": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_device_group_creation": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_display_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_draw_indirect_count": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_driver_properties": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_fence_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_fd": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_external_semaphore_win32": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_display_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_memory_requirements2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_physical_device_properties2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_get_surface_capabilities2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_image_format_list": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_incremental_present": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance1": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance2": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_maintenance3": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_multiview": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_push_descriptor": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_relaxed_block_layout": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_mirror_clamp_to_edge": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_sampler_ycbcr_conversion": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_atomic_int64": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_draw_parameters": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float16_int8": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shader_float_controls": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_shared_presentable_image": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_storage_buffer_storage_class": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_swapchain_mutable_format": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_variable_pointers": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_vulkan_memory_model": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_wayland_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_keyed_mutex": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_win32_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xcb_surface": {
+                                "type": "integer"
+                            },
+                            "VK_KHR_xlib_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_ios_surface": {
+                                "type": "integer"
+                            },
+                            "VK_MVK_macos_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NN_vi_surface": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_device_generated_commands": {
+                                "type": "integer"
+                            },
+                            "VK_NVX_multiview_per_view_attributes": {
+                                "type": "integer"
+                            },
+                            "VK_NV_clip_space_w_scaling": {
+                                "type": "integer"
+                            },
+                            "VK_NV_compute_shader_derivatives": {
+                                "type": "integer"
+                            },
+                            "VK_NV_corner_sampled_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_dedicated_allocation": {
+                                "type": "integer"
+                            },
+                            "VK_NV_device_diagnostic_checkpoints": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_capabilities": {
+                                "type": "integer"
+                            },
+                            "VK_NV_external_memory_win32": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fill_rectangle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_coverage_to_color": {
+                                "type": "integer"
+                            },
+                            "VK_NV_fragment_shader_barycentric": {
+                                "type": "integer"
+                            },
+                            "VK_NV_framebuffer_mixed_samples": {
+                                "type": "integer"
+                            },
+                            "VK_NV_geometry_shader_passthrough": {
+                                "type": "integer"
+                            },
+                            "VK_NV_glsl_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_mesh_shader": {
+                                "type": "integer"
+                            },
+                            "VK_NV_ray_tracing": {
+                                "type": "integer"
+                            },
+                            "VK_NV_representative_fragment_test": {
+                                "type": "integer"
+                            },
+                            "VK_NV_sample_mask_override_coverage": {
+                                "type": "integer"
+                            },
+                            "VK_NV_scissor_exclusive": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_image_footprint": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shader_subgroup_partitioned": {
+                                "type": "integer"
+                            },
+                            "VK_NV_shading_rate_image": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_array2": {
+                                "type": "integer"
+                            },
+                            "VK_NV_viewport_swizzle": {
+                                "type": "integer"
+                            },
+                            "VK_NV_win32_keyed_mutex": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "features": {
+                        "description": "The block that stores features requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures"
+                            },
+                            "VkPhysicalDeviceFeatures2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDeviceFeatures2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFeatures2"
+                            },
+                            "VkPhysicalDevice16BitStorageFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice16BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice16BitStorageFeatures"
+                            },
+                            "VkPhysicalDevice8BitStorageFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevice8BitStorageFeaturesKHR"
+                            },
+                            "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceASTCDecodeFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceBufferAddressFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBufferAddressFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"
+                            },
+                            "VkPhysicalDeviceConditionalRenderingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConditionalRenderingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceCornerSampledImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceCornerSampledImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceExclusiveScissorFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExclusiveScissorFeaturesNV"
+                            },
+                            "VkPhysicalDeviceFloat16Int8FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloat16Int8FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMemoryPriorityFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMemoryPriorityFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderFeaturesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceMultiviewFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewFeatures"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryFeatures"
+                            },
+                            "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerYcbcrConversionFeatures"
+                            },
+                            "VkPhysicalDeviceScalarBlockLayoutFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceShaderAtomicInt64FeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"
+                            },
+                            "VkPhysicalDeviceShaderDrawParameterFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderDrawParameterFeatures"
+                            },
+                            "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderImageFootprintFeaturesNV"
+                            },
+                            "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImageFeaturesNV"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeatures": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVariablePointerFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVariablePointerFeatures"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"
+                            },
+                            "VkPhysicalDeviceVulkanMemoryModelFeaturesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"
+                            }
+                        }
+                    },
+                    "properties": {
+                        "description": "The block that stores properties requirements.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VkPhysicalDeviceProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties"
+                            },
+                            "VkPhysicalDeviceProperties2": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceProperties2KHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProperties2"
+                            },
+                            "VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceConservativeRasterizationPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDepthStencilResolvePropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDepthStencilResolvePropertiesKHR"
+                            },
+                            "VkPhysicalDeviceDescriptorIndexingPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDescriptorIndexingPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDiscardRectanglePropertiesEXT"
+                            },
+                            "VkPhysicalDeviceDriverPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceDriverPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceExternalMemoryHostPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceFloatControlsPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFloatControlsPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceFragmentDensityMapPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceIDProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceIDPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceIDProperties"
+                            },
+                            "VkPhysicalDeviceInlineUniformBlockPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceInlineUniformBlockPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceMaintenance3Properties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMaintenance3PropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMaintenance3Properties"
+                            },
+                            "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMeshShaderPropertiesNV"
+                            },
+                            "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"
+                            },
+                            "VkPhysicalDeviceMultiviewProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDeviceMultiviewPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDeviceMultiviewProperties"
+                            },
+                            "VkPhysicalDevicePCIBusInfoPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDevicePCIBusInfoPropertiesEXT"
+                            },
+                            "VkPhysicalDevicePointClippingProperties": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDevicePointClippingPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePointClippingProperties"
+                            },
+                            "VkPhysicalDeviceProtectedMemoryProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceProtectedMemoryProperties"
+                            },
+                            "VkPhysicalDevicePushDescriptorPropertiesKHR": {
+                                "$ref": "#/definitions/VkPhysicalDevicePushDescriptorPropertiesKHR"
+                            },
+                            "VkPhysicalDeviceRayTracingPropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceRayTracingPropertiesNV"
+                            },
+                            "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSampleLocationsPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceShaderCorePropertiesAMD": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShaderCorePropertiesAMD"
+                            },
+                            "VkPhysicalDeviceShadingRateImagePropertiesNV": {
+                                "$ref": "#/definitions/VkPhysicalDeviceShadingRateImagePropertiesNV"
+                            },
+                            "VkPhysicalDeviceSubgroupProperties": {
+                                "$ref": "#/definitions/VkPhysicalDeviceSubgroupProperties"
+                            },
+                            "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceTransformFeedbackPropertiesEXT"
+                            },
+                            "VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT": {
+                                "$ref": "#/definitions/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"
+                            }
+                        }
+                    },
+                    "formats": {
+                        "description": "The block that store formats capabilities definitions.",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "VK_FORMAT_A1R5G5B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2B10G10R10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A2R10G10B10_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SRGB_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_SSCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UINT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_A8B8G8R8_USCALED_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_10x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x10_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_4x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_5x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_6x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x6_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ASTC_8x8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10G11R11_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B16G16R16G16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B4G4R4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G5R5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B5G6R5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8G8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_B8G8R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGBA_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC1_RGB_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC2_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC3_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC4_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC5_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_SFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC6H_UFLOAT_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_BC7_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D16_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D24_UNORM_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_D32_SFLOAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11G11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_SNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_EAC_R11_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16B16G16R16_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16R16_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8B8G8R8_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8R8_2PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6G10X6_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R10X6_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4G12X4_UNORM_2PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R12X4_UNORM_PACK16_KHR": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16A16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16B16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16G16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R16_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32A32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32B32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32G32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R32_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4B4A4_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R4G4_UNORM_PACK8": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G5B5A1_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R5G6B5_UNORM_PACK16": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64A64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64B64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64G64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SFLOAT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R64_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8A8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8B8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8G8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SRGB": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_SSCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_UNORM": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_R8_USCALED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_S8_UINT": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_UNDEFINED": {
+                                "$ref": "#/definitions/formatProperties"
+                            },
+                            "VK_FORMAT_X8_D24_UNORM_PACK32": {
+                                "$ref": "#/definitions/formatProperties"
+                            }
+                        }
+                    },
+                    "queueFamiliesProperties": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "VkQueueFamilyProperties": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties"
+                                },
+                                "VkQueueFamilyProperties2": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyProperties2KHR": {
+                                    "$ref": "#/definitions/VkQueueFamilyProperties2"
+                                },
+                                "VkQueueFamilyCheckpointPropertiesNV": {
+                                    "$ref": "#/definitions/VkQueueFamilyCheckpointPropertiesNV"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profiles": {
+            "description": "The list of profile definitions.",
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^VP_[A-Z0-9]+_[A-Za-z0-9_]+": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "label",
+                        "description",
+                        "version",
+                        "api-version",
+                        "contributors",
+                        "history",
+                        "capabilities"
+                    ],
+                    "properties": {
+                        "version": {
+                            "description": "The revision of the profile.",
+                            "type": "integer"
+                        },
+                        "label": {
+                            "description": "The label used to present the profile to the Vulkan developer.",
+                            "type": "string"
+                        },
+                        "description": {
+                            "description": "The description of the profile.",
+                            "type": "string"
+                        },
+                        "status": {
+                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "$ref": "#/definitions/status"
+                        },
+                        "api-version": {
+                            "description": "The Vulkan API version against which the profile is written.",
+                            "type": "string",
+                            "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+                        },
+                        "contributors": {
+                            "type": "object",
+                            "description": "The list of contributors of the profile.",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/contributor"
+                            }
+                        },
+                        "history": {
+                            "description": "The version history of the profile file",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "revision",
+                                    "date",
+                                    "author",
+                                    "comment"
+                                ],
+                                "properties": {
+                                    "revision": {
+                                        "type": "integer"
+                                    },
+                                    "date": {
+                                        "type": "string",
+                                        "pattern": "((?:19|20)\\d\\d)-(0?[1-9]|1[012])-([12][0-9]|3[01]|0?[1-9])"
+                                    },
+                                    "author": {
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "capabilities": {
+                            "description": "The list of capability sets that can be reference by a profile.",
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "fallback": {
+                            "description": "The list of profiles recommended if the checked profile is not supported by the platform.",
+                            "type": "array",
+                            "additionalProperties": false,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
No more 0.8.0 schemas in the future, we are bumping to 0.8.1 which is backward compatible. 
Adding schema for all old versions...